### PR TITLE
Add "docker-test" feature to flag to allow testing on mac os

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,13 @@ jobs:
       - name: Cargo check ${{ matrix.os }}
         run: cargo check
 
-      # Ignore tests on macos due to missing docker
       - name: Cargo test
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os != 'macos-latest'
         run: cargo test
+
+      - name: Cargo test without Docker
+        if: matrix.os == 'macos-latest'
+        run: cargo test --no-default-features
 
       - name: Build the binary for ${{ matrix.os }}
         run: cargo build --bin nectar

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,11 @@ reqwest = "0.10.6"
 [dev-dependencies]
 testcontainers = "0.9"
 tokio = { version = "0.2.21", features = ["macros"] }
+
+[features]
+default = ["test-docker"]
+
+# "test-docker" feature is related to test code
+# if it's enabled then tests needing docker will be ran
+test-docker = []
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod swap;
 
-#[cfg(test)]
+#[cfg(all(test, test_docker))]
 pub mod ledgers {
     use reqwest::Url;
     use testcontainers::{

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -215,7 +215,7 @@ impl Swap<hbit::FinalizedAsRedeemer, herc20::Finalized, Bob> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, test_docker))]
 mod test {
     use super::*;
     use crate::ledgers::{BitcoinBlockchain, EthereumBlockchain};


### PR DESCRIPTION
This way, we can still test most on the codebase of mac.
Any test using docker should now be protected behind the `test-docker` feature.