### PR TITLE
Use stable version of comit-rs Nectar branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ dependencies = [
 [[package]]
 name = "cnd"
 version = "0.7.3"
-source = "git+https://github.com/comit-network/comit-rs?branch=nectar#f31a1a0e12c783ad0057b1c06b32abdec645398d"
+source = "git+https://github.com/comit-network/comit-rs?branch=nectar-stable#f31a1a0e12c783ad0057b1c06b32abdec645398d"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "comit"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/comit-rs?branch=nectar#f31a1a0e12c783ad0057b1c06b32abdec645398d"
+source = "git+https://github.com/comit-network/comit-rs?branch=nectar-stable#f31a1a0e12c783ad0057b1c06b32abdec645398d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -745,7 +745,7 @@ dependencies = [
 [[package]]
 name = "digest"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/comit-rs?branch=nectar#f31a1a0e12c783ad0057b1c06b32abdec645398d"
+source = "git+https://github.com/comit-network/comit-rs?branch=nectar-stable#f31a1a0e12c783ad0057b1c06b32abdec645398d"
 dependencies = [
  "digest-macro-derive",
  "hex 0.4.2",
@@ -763,7 +763,7 @@ dependencies = [
 [[package]]
 name = "digest-macro-derive"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/comit-rs?branch=nectar#f31a1a0e12c783ad0057b1c06b32abdec645398d"
+source = "git+https://github.com/comit-network/comit-rs?branch=nectar-stable#f31a1a0e12c783ad0057b1c06b32abdec645398d"
 dependencies = [
  "hex 0.4.2",
  "proc-macro2 1.0.18",
@@ -1540,7 +1540,7 @@ dependencies = [
 [[package]]
 name = "libp2p-comit"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/comit-rs?branch=nectar#f31a1a0e12c783ad0057b1c06b32abdec645398d"
+source = "git+https://github.com/comit-network/comit-rs?branch=nectar-stable#f31a1a0e12c783ad0057b1c06b32abdec645398d"
 dependencies = [
  "bytes",
  "derivative 2.1.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ anyhow = "1"
 async-trait = "0.1"
 bitcoin = "0.23.0"
 chrono = "0.4"
-cnd = { git = "https://github.com/comit-network/comit-rs", package = "cnd", branch = "nectar" }
-comit = { git = "https://github.com/comit-network/comit-rs", package = "comit", branch = "nectar" }
+cnd = { git = "https://github.com/comit-network/comit-rs", package = "cnd", branch = "nectar-stable" }
+comit = { git = "https://github.com/comit-network/comit-rs", package = "comit", branch = "nectar-stable" }
 futures = "0.3.5"
 reqwest = "0.10.6"
 
@@ -24,4 +24,3 @@ default = ["test-docker"]
 # "test-docker" feature is related to test code
 # if it's enabled then tests needing docker will be ran
 test-docker = []
-


### PR DESCRIPTION
The dependency can be updated to a stable commit hash belonging to the comit-rs dev once https://github.com/comit-network/comit-rs/pull/2838 gets merged.