### PR TITLE
Defined single hbit_herc20 function for Alice and Bob

### DIFF
--- a/src/bitcoind.rs
+++ b/src/bitcoind.rs
@@ -9,7 +9,6 @@ pub struct Client {
 
 impl Client {
     pub fn new(url: reqwest::Url) -> Self {
-        dbg!(&url);
         Client {
             rpc_client: jsonrpc::Client::new(url),
         }

--- a/src/ongoing_swaps.rs
+++ b/src/ongoing_swaps.rs
@@ -34,7 +34,7 @@ impl OngoingSwaps {
             Ok(())
         }
     }
-    fn remove(&mut self, order: &Order) {
+    fn remove(&mut self, order: Order) {
         self.peers.remove(&order.peer);
     }
 }
@@ -100,7 +100,7 @@ mod tests {
 
         let insertion_1 = state.insert(order_1);
         // Execution is not represented in the test, order should be removed once execution is done.
-        state.remove(&order_1);
+        state.remove(order_1);
 
         let insertion_2 = state.insert(order_2);
 


### PR DESCRIPTION
The function can be used by both parties, ensuring that the execution of a swap cannot get out of sync.

The function is generic over actors which have to implement certain actions. In `WalletACTOR` implementations, a wallet is used to actually peform the action; in `WatchOnlyACTOR` implementations, `btsieve` is used to monitor the blockchain.

Temporary `BitcoinWallet` and `EthereumWallet` dummy types are introduced to satisfy the compiler. They will eventually be replaced by traits implemented by wallets (such as the ones which will actually power Nectar).

---

Opened PR as an FYI and in order to move the state of master forward. I already got feedback whilst working on it. Nevertheless, feel free to leave comments.