### PR TITLE
Allow and prioritise refund during swap execution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1.0"
 strum = "0.18"
 strum_macros = "0.18"
 thiserror = "1.0"
+tokio = { version = "0.2", features = ["time"] }
 tracing = "0.1.15"
 
 [dependencies.rand]


### PR DESCRIPTION
I'm happy to move forward with this simpler design. Let me know if the logic is sound.

I'm not sure how this new design would fit in with two watch-only actors (cnd's use-case), but I think it's okay for Nectar.