### PR TITLE
Remove float arithmetic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,6 +433,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "conquer-once"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f7644600a548ecad74e4a918392af1798f7dd045be610be3203b9e129b4f98f"
+dependencies = [
+ "conquer-util",
+]
+
+[[package]]
+name = "conquer-util"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654fb2472cc369d311c547103a1fa81d467bef370ae7a0680f65939895b1182a"
+
+[[package]]
 name = "const-random"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,8 +1603,8 @@ dependencies = [
  "bitcoin",
  "chrono",
  "comit",
+ "conquer-once",
  "futures",
- "lazy_static",
  "num",
  "proptest",
  "rand 0.6.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
+
+[[package]]
 name = "bitcoin"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,6 +1590,8 @@ dependencies = [
  "comit",
  "futures",
  "lazy_static",
+ "num",
+ "proptest",
  "rand 0.6.5",
  "reqwest",
  "serde",
@@ -1969,6 +1986,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2520fe6373cf6a3a61e2d200e987c183778ade8d9248ac3e6614ab0edfe4a0c1"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
+ "rand_xorshift 0.2.0",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+]
+
+[[package]]
 name = "prost"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,6 +2057,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quicksink"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,7 +2112,7 @@ dependencies = [
  "rand_jitter",
  "rand_os",
  "rand_pcg",
- "rand_xorshift",
+ "rand_xorshift 0.1.1",
  "winapi 0.3.8",
 ]
 
@@ -2202,6 +2245,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2314,6 +2366,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -3012,6 +3076,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ async-trait = "0.1"
 bitcoin = { version = "0.23.0", features = ["rand"] }
 chrono = "0.4"
 comit = { git = "https://github.com/comit-network/comit-rs", package = "comit", branch = "nectar" }
+conquer-once = "0.2"
 futures = "0.3.5"
-lazy_static = "1.4"
 num = "0.2"
 reqwest = "0.10.6"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ chrono = "0.4"
 comit = { git = "https://github.com/comit-network/comit-rs", package = "comit", branch = "nectar" }
 futures = "0.3.5"
 lazy_static = "1.4"
+num = "0.2"
 reqwest = "0.10.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -26,6 +27,7 @@ default-features = false
 version = "0.6"
 
 [dev-dependencies]
+proptest = "0.10"
 testcontainers = "0.9"
 tokio = { version = "0.2.21", features = ["macros"] }
 

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -99,7 +99,7 @@ mod tests {
 
         let res: dai::Amount = btc.worth_in(rate).unwrap();
 
-        let dai = dai::Amount::from_dai_trunc(31475.88732).unwrap();
+        let dai = dai::Amount::from_dai_trunc(3147.59232).unwrap();
         assert_eq!(res, dai);
     }
 

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -84,33 +84,33 @@ mod tests {
     #[test]
     fn worth_in_1() {
         let btc = Amount::from_btc(1.0).unwrap();
-        let rate = Rate::from_f64(1000.1234).unwrap();
+        let rate = Rate::from_f64(1_000.123_4).unwrap();
 
         let res: dai::Amount = btc.worth_in(rate).unwrap();
 
-        let dai = dai::Amount::from_dai_trunc(1000.1234).unwrap();
+        let dai = dai::Amount::from_dai_trunc(1_000.123_4).unwrap();
         assert_eq!(res, dai);
     }
 
     #[test]
     fn worth_in_2() {
-        let btc = Amount::from_btc(0.3456789).unwrap();
-        let rate = Rate::from_f64(9123.4567).unwrap();
+        let btc = Amount::from_btc(0.345_678_9).unwrap();
+        let rate = Rate::from_f64(9_123.456_7).unwrap();
 
         let res: dai::Amount = btc.worth_in(rate).unwrap();
 
-        let dai = dai::Amount::from_dai_trunc(3153.78647625363).unwrap();
+        let dai = dai::Amount::from_dai_trunc(3_153.786_476_253_63).unwrap();
         assert_eq!(res, dai);
     }
 
     #[test]
     fn worth_in_3() {
-        let btc = Amount::from_btc(0.0107).unwrap();
-        let rate = Rate::from_f64(9355.38).unwrap();
+        let btc = Amount::from_btc(0.010_7).unwrap();
+        let rate = Rate::from_f64(9_355.38).unwrap();
 
         let res: dai::Amount = btc.worth_in(rate).unwrap();
 
-        let dai = dai::Amount::from_dai_trunc(100.102566).unwrap();
+        let dai = dai::Amount::from_dai_trunc(100.102_566).unwrap();
         assert_eq!(res, dai);
     }
 

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -31,7 +31,7 @@ impl Amount {
 // The rate input is for bitcoin to dai but we applied to satoshis so we need to:
 // - divide to get bitcoins (8)
 // - divide to adjust for rate (9)
-// - multiple to get attodai (18)
+// - multiply to get attodai (18)
 // = 1
 const ADJUSTEMENT_EXP: u16 = ATTOS_IN_DAI_EXP - SATS_IN_BITCOIN_EXP - Rate::PRECISION;
 

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -82,12 +82,36 @@ mod tests {
     use proptest::prelude::*;
 
     #[test]
-    fn using_rate_returns_correct_result() {
+    fn worth_in_1() {
         let btc = Amount::from_btc(1.0).unwrap();
+        let rate = Rate::from_f64(1000.1234).unwrap();
 
-        let res: dai::Amount = btc.worth_in(Rate::from_f64(1000.1234).unwrap()).unwrap();
+        let res: dai::Amount = btc.worth_in(rate).unwrap();
 
-        assert_eq!(res, dai::Amount::from_dai_trunc(1000.1234).unwrap());
+        let dai = dai::Amount::from_dai_trunc(1000.1234).unwrap();
+        assert_eq!(res, dai);
+    }
+
+    #[test]
+    fn worth_in_2() {
+        let btc = Amount::from_btc(0.345).unwrap();
+        let rate = Rate::from_f64(9123.456).unwrap();
+
+        let res: dai::Amount = btc.worth_in(rate).unwrap();
+
+        let dai = dai::Amount::from_dai_trunc(31475.88732).unwrap();
+        assert_eq!(res, dai);
+    }
+
+    #[test]
+    fn worth_in_3() {
+        let btc = Amount::from_btc(0.0107).unwrap();
+        let rate = Rate::from_f64(9355.38).unwrap();
+
+        let res: dai::Amount = btc.worth_in(rate).unwrap();
+
+        let dai = dai::Amount::from_dai_trunc(100.102566).unwrap();
+        assert_eq!(res, dai);
     }
 
     proptest! {

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -94,12 +94,12 @@ mod tests {
 
     #[test]
     fn worth_in_2() {
-        let btc = Amount::from_btc(0.345).unwrap();
-        let rate = Rate::from_f64(9123.456).unwrap();
+        let btc = Amount::from_btc(0.3456789).unwrap();
+        let rate = Rate::from_f64(9123.4567).unwrap();
 
         let res: dai::Amount = btc.worth_in(rate).unwrap();
 
-        let dai = dai::Amount::from_dai_trunc(3147.59232).unwrap();
+        let dai = dai::Amount::from_dai_trunc(3153.78647625363).unwrap();
         assert_eq!(res, dai);
     }
 

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -2,8 +2,6 @@ use crate::dai;
 use crate::dai::ATTOS_IN_DAI_EXP;
 use crate::publish::WorthIn;
 use crate::rate::Rate;
-use num::pow::Pow;
-use num::BigUint;
 
 pub const SATS_IN_BITCOIN_EXP: u16 = 8;
 
@@ -43,7 +41,7 @@ impl WorthIn<dai::Amount> for Amount {
         // Apply the rate
         let worth = uint_rate * self.as_sat();
 
-        let atto_dai = worth * BigUint::from(10u16).pow(BigUint::from(ADJUSTEMENT_EXP));
+        let atto_dai = worth * 10u16.pow(ADJUSTEMENT_EXP.into());
 
         Ok(dai::Amount::from_atto(atto_dai))
     }

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -61,11 +61,12 @@ impl std::ops::Sub for Amount {
 mod tests {
     use super::*;
     use proptest::prelude::*;
+    use std::convert::TryFrom;
 
     #[test]
     fn worth_in_1() {
         let btc = Amount::from_btc(1.0).unwrap();
-        let rate = Rate::from_f64(1_000.123_4).unwrap();
+        let rate = Rate::try_from(1_000.123_4).unwrap();
 
         let res: dai::Amount = btc.worth_in(rate).unwrap();
 
@@ -76,7 +77,7 @@ mod tests {
     #[test]
     fn worth_in_2() {
         let btc = Amount::from_btc(0.345_678_9).unwrap();
-        let rate = Rate::from_f64(9_123.456_7).unwrap();
+        let rate = Rate::try_from(9_123.456_7).unwrap();
 
         let res: dai::Amount = btc.worth_in(rate).unwrap();
 
@@ -87,7 +88,7 @@ mod tests {
     #[test]
     fn worth_in_3() {
         let btc = Amount::from_btc(0.010_7).unwrap();
-        let rate = Rate::from_f64(9_355.38).unwrap();
+        let rate = Rate::try_from(9_355.38).unwrap();
 
         let res: dai::Amount = btc.worth_in(rate).unwrap();
 
@@ -98,7 +99,7 @@ mod tests {
     #[test]
     fn worth_in_4() {
         let btc = Amount::from_btc(9999.0).unwrap();
-        let rate = Rate::from_f64(10.0).unwrap();
+        let rate = Rate::try_from(10.0).unwrap();
 
         let res: dai::Amount = btc.worth_in(rate).unwrap();
 
@@ -110,7 +111,7 @@ mod tests {
         #[test]
         fn worth_in_dai_doesnt_panic(u in any::<u64>(), r in any::<f64>()) {
             let amount = Amount::from_sat(u);
-            let rate = Rate::from_f64(r);
+            let rate = Rate::try_from(r);
             if let Ok(rate) = rate {
                 let _: anyhow::Result<dai::Amount> = amount.worth_in(rate);
             }

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -38,7 +38,7 @@ const ADJUSTEMENT_EXP: u16 = ATTOS_IN_DAI_EXP - SATS_IN_BITCOIN_EXP - Rate::PREC
 impl WorthIn<dai::Amount> for Amount {
     fn worth_in(&self, btc_to_dai_rate: Rate) -> anyhow::Result<dai::Amount> {
         // Get the integer part of the rate
-        let uint_rate = BigUint::from(btc_to_dai_rate.integer());
+        let uint_rate = btc_to_dai_rate.integer();
 
         // Apply the rate
         let worth = uint_rate * self.as_sat();

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -1,0 +1,103 @@
+use crate::dai;
+use crate::dai::ATTOS_IN_DAI_EXP;
+use crate::float_maths::divide_pow_ten_trunc;
+use crate::publish::WorthIn;
+use crate::rate::Rate;
+use anyhow::anyhow;
+use bitcoin::hashes::core::cmp::Ordering;
+use num::pow::Pow;
+use num::BigUint;
+use std::convert::TryFrom;
+
+pub const SATS_IN_BITCOIN_EXP: u16 = 8;
+
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, PartialEq, Eq)]
+pub struct Amount(::bitcoin::Amount);
+
+impl Amount {
+    pub fn from_btc(btc: f64) -> anyhow::Result<Amount> {
+        Ok(Amount(::bitcoin::Amount::from_btc(btc)?))
+    }
+
+    pub fn from_sat(sat: u64) -> Self {
+        Amount(::bitcoin::Amount::from_sat(sat))
+    }
+
+    pub fn as_sat(self) -> u64 {
+        self.0.as_sat()
+    }
+
+    pub fn as_btc(self) -> f64 {
+        self.0.as_btc()
+    }
+}
+
+impl WorthIn<dai::Amount> for Amount {
+    fn worth_in(&self, btc_to_dai_rate: Rate) -> anyhow::Result<dai::Amount> {
+        // Get the integer part of the rate
+        let uint_rate = BigUint::from(btc_to_dai_rate.integer());
+
+        // Apply the rate
+        let worth = uint_rate * self.as_sat();
+
+        // The rate input is for bitcoin to dai but we applied to satoshis so we need to:
+        // - divide to get bitcoins
+        // - divide to adjust for rate (we used integer part only).
+        // - multiple to get attodai
+        let sats_in_bitcoin = i32::from(SATS_IN_BITCOIN_EXP);
+        let rate_exp = i32::try_from(btc_to_dai_rate.inverse_decimal_exponent())
+            .map_err(|_| anyhow!("Exponent is unexpectedly large."))?;
+        let attos_in_dai = i32::from(ATTOS_IN_DAI_EXP);
+        let adjustment_exp = -sats_in_bitcoin - rate_exp + attos_in_dai;
+
+        let atto_dai = match adjustment_exp.cmp(&0) {
+            Ordering::Less => {
+                let inv_exp = usize::try_from(adjustment_exp.abs())
+                    .map_err(|_| anyhow!("Exponent is unexpectedly large."))?;
+                divide_pow_ten_trunc(worth, inv_exp)
+            }
+            Ordering::Equal => worth,
+            Ordering::Greater => {
+                let exp = u16::try_from(adjustment_exp)
+                    .map_err(|_| anyhow!("Exponent is unexpectedly large."))?;
+                worth * BigUint::from(10u16).pow(BigUint::from(exp))
+            }
+        };
+
+        Ok(dai::Amount::from_atto(atto_dai))
+    }
+}
+
+impl std::ops::Sub for Amount {
+    type Output = Amount;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Amount(self.0 - rhs.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn using_rate_returns_correct_result() {
+        let btc = Amount::from_btc(1.0).unwrap();
+
+        let res: dai::Amount = btc.worth_in(Rate::from_f64(1000.1234).unwrap()).unwrap();
+
+        assert_eq!(res, dai::Amount::from_dai_trunc(1000.1234).unwrap());
+    }
+
+    proptest! {
+        #[test]
+        fn worth_in_dai_doesnt_panic(u in any::<u64>(), r in any::<f64>()) {
+            let amount = Amount::from_sat(u);
+            let rate = Rate::from_f64(r);
+            if let Ok(rate) = rate {
+                let _: anyhow::Result<dai::Amount> = amount.worth_in(rate);
+            }
+        }
+    }
+}

--- a/src/dai.rs
+++ b/src/dai.rs
@@ -61,7 +61,7 @@ const ADJUSTEMENT_EXP: i32 =
 impl WorthIn<crate::bitcoin::Amount> for Amount {
     fn worth_in(&self, dai_to_btc_rate: Rate) -> anyhow::Result<bitcoin::Amount> {
         // Get the integer part of the rate
-        let uint_rate = BigUint::from(dai_to_btc_rate.integer());
+        let uint_rate = dai_to_btc_rate.integer();
 
         // Apply the rate
         let worth = uint_rate * self.as_atto();

--- a/src/dai.rs
+++ b/src/dai.rs
@@ -124,10 +124,36 @@ mod tests {
     #[test]
     fn using_rate_returns_correct_result() {
         let dai = Amount::from_dai_trunc(1.0).unwrap();
+        let rate = Rate::from_f64(0.001_234).unwrap();
 
-        let res: bitcoin::Amount = dai.worth_in(Rate::from_f64(0.001234).unwrap()).unwrap();
+        let res: bitcoin::Amount = dai.worth_in(rate).unwrap();
 
-        assert_eq!(res, bitcoin::Amount::from_btc(0.001234).unwrap());
+        let btc = bitcoin::Amount::from_btc(0.001_234).unwrap();
+        assert_eq!(res, btc);
+    }
+
+    #[test]
+    fn worth_in_result_truncated_1() {
+        let dai = Amount::from_dai_trunc(101.0).unwrap();
+        let rate = Rate::from_f64(0.000_123_456).unwrap();
+
+        let res: bitcoin::Amount = dai.worth_in(rate).unwrap();
+
+        // Result is 0.012469056 btc or 1246905.6 satoshis
+        let btc = bitcoin::Amount::from_btc(0.012_469_05).unwrap();
+        assert_eq!(res, btc);
+    }
+
+    #[test]
+    fn worth_in_result_truncated_2() {
+        let dai = Amount::from_dai_trunc(100_001.0).unwrap();
+        let rate = Rate::from_f64(0.000_001_234).unwrap();
+
+        let res: bitcoin::Amount = dai.worth_in(rate).unwrap();
+
+        // Result is 12,340,123.4 satoshis
+        let btc = bitcoin::Amount::from_sat(12_340_123);
+        assert_eq!(res, btc);
     }
 
     proptest! {

--- a/src/dai.rs
+++ b/src/dai.rs
@@ -1,5 +1,5 @@
 use crate::bitcoin::{self, SATS_IN_BITCOIN_EXP};
-use crate::float_maths::{divide_pow_ten_trunc, multiple_pow_ten, truncate};
+use crate::float_maths::{divide_pow_ten_trunc, multiply_pow_ten, truncate};
 use crate::publish::WorthIn;
 use crate::rate::Rate;
 use conquer_once::Lazy;
@@ -24,7 +24,7 @@ impl Amount {
 
         let dai = truncate(dai, ATTOS_IN_DAI_EXP);
 
-        let u_int_value = multiple_pow_ten(dai, ATTOS_IN_DAI_EXP).expect("It is truncated");
+        let u_int_value = multiply_pow_ten(dai, ATTOS_IN_DAI_EXP).expect("It is truncated");
 
         Ok(Amount(u_int_value))
     }
@@ -53,7 +53,7 @@ impl std::fmt::Display for Amount {
 // The rate input is for dai to bitcoin but we applied it to attodai so we need to:
 // - divide to get dai (18)
 // - divide to adjust for rate (9)
-// - multiple to get satoshis (8)
+// - multiply to get satoshis (8)
 // = - 19
 const ADJUSTEMENT_EXP: i32 =
     SATS_IN_BITCOIN_EXP as i32 - ATTOS_IN_DAI_EXP as i32 - Rate::PRECISION as i32;

--- a/src/dai.rs
+++ b/src/dai.rs
@@ -1,0 +1,154 @@
+use crate::bitcoin::{self, SATS_IN_BITCOIN_EXP};
+use crate::float_maths::{divide_pow_ten_trunc, multiple_pow_ten, truncate};
+use crate::publish::WorthIn;
+use crate::rate::Rate;
+use anyhow::anyhow;
+use num::{pow::Pow, BigUint, ToPrimitive};
+use std::cmp::Ordering;
+use std::convert::TryFrom;
+
+pub const ATTOS_IN_DAI_EXP: u16 = 18;
+
+lazy_static::lazy_static! {
+    pub static ref DAI_DEC: BigUint =
+        BigUint::from(10u16).pow(ATTOS_IN_DAI_EXP);
+}
+
+#[derive(Clone, Ord, PartialOrd, PartialEq, Eq)]
+pub struct Amount(BigUint);
+
+impl Amount {
+    /// Rounds the value received to a 9 digits mantissa.
+    pub fn from_dai_trunc(dai: f64) -> anyhow::Result<Self> {
+        if dai.is_sign_negative() {
+            anyhow::bail!("Passed value is negative")
+        }
+
+        if !dai.is_finite() {
+            anyhow::bail!("Passed value is not finite")
+        }
+
+        let dai = truncate(dai, ATTOS_IN_DAI_EXP);
+
+        let u_int_value = multiple_pow_ten(dai, ATTOS_IN_DAI_EXP).expect("It is truncated");
+
+        Ok(Amount(u_int_value))
+    }
+
+    pub fn from_atto(atto: BigUint) -> Self {
+        Amount(atto)
+    }
+
+    pub fn as_atto(&self) -> BigUint {
+        self.0.clone()
+    }
+}
+
+impl std::fmt::Debug for Amount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::fmt::Display for Amount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl WorthIn<crate::bitcoin::Amount> for Amount {
+    fn worth_in(&self, dai_to_btc_rate: Rate) -> anyhow::Result<bitcoin::Amount> {
+        // Get the integer part of the rate
+        let uint_rate = BigUint::from(dai_to_btc_rate.integer());
+
+        // Apply the rate
+        let worth = uint_rate * self.as_atto();
+
+        // The rate input is for dai to bitcoin but we applied it to attodai so we need to:
+        // - divide to get dai
+        // - divide to adjust for rate (we used integer part only).
+        // - multiple to get satoshis
+        let attos_in_dai = i32::from(ATTOS_IN_DAI_EXP);
+        let rate_exp = i32::try_from(dai_to_btc_rate.inverse_decimal_exponent())
+            .map_err(|_| anyhow!("Exponent is unexpectedly large."))?;
+        let sats_in_bitcoin = i32::from(SATS_IN_BITCOIN_EXP);
+        let adjustment_exp = -attos_in_dai - rate_exp + sats_in_bitcoin;
+
+        let sats = match adjustment_exp.cmp(&0) {
+            Ordering::Less => {
+                let inv_exp = usize::try_from(adjustment_exp.abs())
+                    .map_err(|_| anyhow!("Exponent is unexpectedly large."))?;
+                divide_pow_ten_trunc(worth, inv_exp)
+            }
+            Ordering::Equal => worth,
+            Ordering::Greater => {
+                let exp = usize::try_from(adjustment_exp)
+                    .map_err(|_| anyhow!("Exponent is unexpectedly large."))?;
+                worth * BigUint::from(10u16).pow(BigUint::from(exp))
+            }
+        }
+        .to_u64()
+        .ok_or_else(|| anyhow::anyhow!("Result is unexpectedly large"))?;
+
+        Ok(bitcoin::Amount::from_sat(sats))
+    }
+}
+
+impl std::ops::Sub for Amount {
+    type Output = Amount;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Amount(self.0 - rhs.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn given_float_dai_amount_less_precise_than_attodai_then_exact_value_is_stored() {
+        let some_dai = Amount::from_dai_trunc(1.555_555_555).unwrap();
+        let same_amount = Amount::from_atto(BigUint::from(1_555_555_555_000_000_000u64));
+
+        assert_eq!(some_dai, same_amount);
+    }
+
+    #[test]
+    fn given_float_dai_amount_more_precise_than_attodai_then_stored_value_is_truncated() {
+        let some_dai = Amount::from_dai_trunc(0.000_000_555_555_555_555_5).unwrap();
+        let same_amount = Amount::from_atto(BigUint::from(555_555_555_555u64));
+
+        assert_eq!(some_dai, same_amount);
+    }
+
+    #[test]
+    fn using_rate_returns_correct_result() {
+        let dai = Amount::from_dai_trunc(1.0).unwrap();
+
+        let res: bitcoin::Amount = dai.worth_in(Rate::from_f64(0.001234).unwrap()).unwrap();
+
+        assert_eq!(res, bitcoin::Amount::from_btc(0.001234).unwrap());
+    }
+
+    proptest! {
+        #[test]
+        fn doesnt_panic(f in any::<f64>()) {
+               let _ = Amount::from_dai_trunc(f);
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn worth_in_bitcoin_doesnt_panic(s in "[0-9]+", r in any::< f64>()) {
+            let uint = BigUint::from_str(&s);
+            let rate = Rate::from_f64(r);
+            if let (Ok(uint), Ok(rate)) = (uint, rate) {
+                let amount = Amount::from_atto(uint);
+                let _: anyhow::Result<bitcoin::Amount> = amount.worth_in(rate);
+            }
+        }
+    }
+}

--- a/src/dai.rs
+++ b/src/dai.rs
@@ -87,6 +87,7 @@ impl std::ops::Sub for Amount {
 mod tests {
     use super::*;
     use proptest::prelude::*;
+    use std::convert::TryFrom;
     use std::str::FromStr;
 
     #[test]
@@ -108,7 +109,7 @@ mod tests {
     #[test]
     fn using_rate_returns_correct_result() {
         let dai = Amount::from_dai_trunc(1.0).unwrap();
-        let rate = Rate::from_f64(0.001_234).unwrap();
+        let rate = Rate::try_from(0.001_234).unwrap();
 
         let res: bitcoin::Amount = dai.worth_in(rate).unwrap();
 
@@ -119,7 +120,7 @@ mod tests {
     #[test]
     fn worth_in_result_truncated_1() {
         let dai = Amount::from_dai_trunc(101.0).unwrap();
-        let rate = Rate::from_f64(0.000_123_456).unwrap();
+        let rate = Rate::try_from(0.000_123_456).unwrap();
 
         let res: bitcoin::Amount = dai.worth_in(rate).unwrap();
 
@@ -131,7 +132,7 @@ mod tests {
     #[test]
     fn worth_in_result_truncated_2() {
         let dai = Amount::from_dai_trunc(100_001.0).unwrap();
-        let rate = Rate::from_f64(0.000_001_234).unwrap();
+        let rate = Rate::try_from(0.000_001_234).unwrap();
 
         let res: bitcoin::Amount = dai.worth_in(rate).unwrap();
 
@@ -151,7 +152,7 @@ mod tests {
         #[test]
         fn worth_in_bitcoin_doesnt_panic(s in "[0-9]+", r in any::< f64>()) {
             let uint = BigUint::from_str(&s);
-            let rate = Rate::from_f64(r);
+            let rate = Rate::try_from(r);
             if let (Ok(uint), Ok(rate)) = (uint, rate) {
                 let amount = Amount::from_atto(uint);
                 let _: anyhow::Result<bitcoin::Amount> = amount.worth_in(rate);

--- a/src/dai.rs
+++ b/src/dai.rs
@@ -3,16 +3,13 @@ use crate::float_maths::{divide_pow_ten_trunc, multiple_pow_ten, truncate};
 use crate::publish::WorthIn;
 use crate::rate::Rate;
 use anyhow::anyhow;
+use conquer_once::Lazy;
 use num::{pow::Pow, BigUint, ToPrimitive};
 use std::cmp::Ordering;
 use std::convert::TryFrom;
 
 pub const ATTOS_IN_DAI_EXP: u16 = 18;
-
-lazy_static::lazy_static! {
-    pub static ref DAI_DEC: BigUint =
-        BigUint::from(10u16).pow(ATTOS_IN_DAI_EXP);
-}
+pub static DAI_DEC: Lazy<BigUint> = Lazy::new(|| BigUint::from(10u16).pow(ATTOS_IN_DAI_EXP));
 
 #[derive(Clone, Ord, PartialOrd, PartialEq, Eq)]
 pub struct Amount(BigUint);

--- a/src/float_maths.rs
+++ b/src/float_maths.rs
@@ -62,7 +62,7 @@ pub fn multiply_pow_ten(float: f64, pow: u16) -> anyhow::Result<BigUint> {
     }
 }
 
-/// Divide BigUint by 10e`-inv_pow`, Returns as a BigUint.
+/// Divide BigUint by 10e`inv_pow`, Returns as a BigUint.
 /// Result is truncated
 pub fn divide_pow_ten_trunc(uint: BigUint, inv_pow: usize) -> BigUint {
     let mut uint_str = uint.to_string();

--- a/src/float_maths.rs
+++ b/src/float_maths.rs
@@ -43,25 +43,20 @@ pub fn multiply_pow_ten(float: f64, pow: u16) -> anyhow::Result<BigUint> {
             float.truncate(float.len() - 1);
             let integer = float;
 
-            if mantissa.is_empty() {
-                unreachable!("already covered with decimal_index == None");
-            } else {
-                let pow = pow as usize;
-                match mantissa.len().cmp(&pow) {
-                    Ordering::Less => {
-                        let remain = pow as usize - mantissa.len();
-                        let zeroes = "0".repeat(remain);
-                        Ok(
-                            BigUint::from_str(&format!("{}{}{}", integer, mantissa, zeroes))
-                                .expect("an integer"),
-                        )
-                    }
-                    Ordering::Equal => {
-                        Ok(BigUint::from_str(&format!("{}{}", integer, mantissa))
-                            .expect("an integer"))
-                    }
-                    Ordering::Greater => anyhow::bail!("Result is not an integer"),
+            let pow = pow as usize;
+            match mantissa.len().cmp(&pow) {
+                Ordering::Less => {
+                    let remain = pow as usize - mantissa.len();
+                    let zeroes = "0".repeat(remain);
+                    Ok(
+                        BigUint::from_str(&format!("{}{}{}", integer, mantissa, zeroes))
+                            .expect("an integer"),
+                    )
                 }
+                Ordering::Equal => {
+                    Ok(BigUint::from_str(&format!("{}{}", integer, mantissa)).expect("an integer"))
+                }
+                Ordering::Greater => anyhow::bail!("Result is not an integer"),
             }
         }
     }

--- a/src/float_maths.rs
+++ b/src/float_maths.rs
@@ -69,7 +69,7 @@ pub fn divide_pow_ten_trunc(uint: BigUint, inv_pow: usize) -> BigUint {
 
     match uint_str.len().cmp(&inv_pow) {
         Ordering::Less => BigUint::zero(),
-        Ordering::Equal => uint,
+        Ordering::Equal => BigUint::zero(),
         Ordering::Greater => {
             uint_str.truncate(uint_str.len() - inv_pow);
             BigUint::from_str(&uint_str).expect("still an integer")
@@ -168,9 +168,23 @@ mod tests {
 
     #[test]
     fn given_pow_zero_it_doesnt_modifies() {
-        let uint = BigUint::from(1_234_456_789u64);
+        let uint = BigUint::from(1_234_567_890u64);
         let pow = 0;
         assert_eq!(divide_pow_ten_trunc(uint.clone(), pow), uint)
+    }
+
+    #[test]
+    fn given_pow_greater_than_uint_it_truncates_to_zero_1() {
+        let uint = BigUint::from(1_234_567_890u64);
+        let pow = 10;
+        assert_eq!(divide_pow_ten_trunc(uint.clone(), pow), BigUint::zero())
+    }
+
+    #[test]
+    fn given_pow_greater_than_uint_it_truncates_to_zero_2() {
+        let uint = BigUint::from(1_234_456_789u64);
+        let pow = 11;
+        assert_eq!(divide_pow_ten_trunc(uint.clone(), pow), BigUint::zero())
     }
 
     proptest! {

--- a/src/float_maths.rs
+++ b/src/float_maths.rs
@@ -1,0 +1,190 @@
+use bitcoin::hashes::core::cmp::Ordering;
+use num::{BigUint, Zero};
+use std::str::FromStr;
+
+/// Truncate the float's mantissa to length `precision`.
+pub fn truncate(float: f64, precision: u16) -> f64 {
+    let mut string = float.to_string();
+    let index = string.find('.');
+
+    match index {
+        None => float,
+        Some(index) => {
+            let trunc = index + 1 + precision as usize;
+            string.truncate(trunc);
+            f64::from_str(&string).expect("This should still be a number")
+        }
+    }
+}
+
+/// Multiple float by 10e`pow`, Returns as a BigUint. No data loss.
+/// Errors if the float is negative.
+/// Errors if the result is a fraction.
+pub fn multiple_pow_ten(float: f64, pow: u16) -> anyhow::Result<BigUint> {
+    if float.is_sign_negative() {
+        anyhow::bail!("Float is negative");
+    }
+
+    if !float.is_finite() {
+        anyhow::bail!("Float is not finite");
+    }
+
+    let mut float = float.to_string();
+    let decimal_index = float.find('.');
+
+    match decimal_index {
+        None => {
+            let zeroes = "0".repeat(pow as usize);
+            Ok(BigUint::from_str(&format!("{}{}", float, zeroes)).expect("an integer"))
+        }
+        Some(decimal_index) => {
+            let mantissa = float.split_off(decimal_index + 1);
+            // Removes the decimal point
+            float.truncate(float.len() - 1);
+            let integer = float;
+
+            if mantissa.is_empty() {
+                unreachable!("already covered with decimal_index == None");
+            } else {
+                let pow = pow as usize;
+                match mantissa.len().cmp(&pow) {
+                    Ordering::Less => {
+                        let remain = pow as usize - mantissa.len();
+                        let zeroes = "0".repeat(remain);
+                        Ok(
+                            BigUint::from_str(&format!("{}{}{}", integer, mantissa, zeroes))
+                                .expect("an integer"),
+                        )
+                    }
+                    Ordering::Equal => {
+                        Ok(BigUint::from_str(&format!("{}{}", integer, mantissa))
+                            .expect("an integer"))
+                    }
+                    Ordering::Greater => anyhow::bail!("Result is not an integer"),
+                }
+            }
+        }
+    }
+}
+
+/// Divide BigUint by 10e`-inv_pow`, Returns as a BigUint.
+/// Result is truncated
+pub fn divide_pow_ten_trunc(uint: BigUint, inv_pow: usize) -> BigUint {
+    let mut uint_str = uint.to_string();
+
+    match uint_str.len().cmp(&inv_pow) {
+        Ordering::Less => BigUint::zero(),
+        Ordering::Equal => uint,
+        Ordering::Greater => {
+            uint_str.truncate(uint_str.len() - inv_pow);
+            BigUint::from_str(&uint_str).expect("still an integer")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn it_truncates() {
+        let float = 1.123456789;
+
+        assert_eq!(&truncate(float, 5).to_string(), "1.12345");
+    }
+
+    proptest! {
+        #[test]
+        fn truncate_doesnt_panic(f in any::<f64>(), p in any::<u16>()) {
+            truncate(f, p);
+        }
+    }
+
+    #[test]
+    fn given_integer_then_it_multiplies() {
+        let float = 123_456_789.0f64;
+        let pow = 6;
+
+        assert_eq!(
+            multiple_pow_ten(float, pow).unwrap(),
+            BigUint::from(123_456_789_000_000u64)
+        )
+    }
+
+    #[test]
+    fn given_mantissa_of_pow_length_then_it_multiplies() {
+        let float = 123.123_456_789f64;
+        let pow = 9;
+
+        assert_eq!(
+            multiple_pow_ten(float, pow).unwrap(),
+            BigUint::from(123_123_456_789u64)
+        )
+    }
+
+    #[test]
+    fn given_mantissa_length_lesser_than_pow_then_it_multiplies() {
+        let float = 123.123_456_789f64;
+        let pow = 12;
+
+        assert_eq!(
+            multiple_pow_ten(float, pow).unwrap(),
+            BigUint::from(123_123_456_789_000u64)
+        )
+    }
+
+    #[test]
+    fn given_mantissa_length_greater_than_pow_then_it_errors() {
+        let float = 123.123_456_789f64;
+        let pow = 6;
+
+        assert!(multiple_pow_ten(float, pow).is_err(),)
+    }
+
+    #[test]
+    fn given_negative_float_then_it_errors() {
+        let float = -123_456_789.0f64;
+        let pow = 6;
+
+        assert!(multiple_pow_ten(float, pow).is_err(),)
+    }
+
+    proptest! {
+        #[test]
+        fn multiple_pow_ten_doesnt_panic(f in any::<f64>(), p in any::<u16>()) {
+            let _ = multiple_pow_ten(f, p);
+        }
+    }
+
+    #[test]
+    fn given_too_precise_uint_it_truncates() {
+        let uint = BigUint::from(1_000_000_001u64);
+        let pow = 6;
+        assert_eq!(divide_pow_ten_trunc(uint, pow), BigUint::from(1_000u64))
+    }
+
+    #[test]
+    fn given_not_that_precise_uint_it_doesnt_truncate() {
+        let uint = BigUint::from(1_234_000_000u64);
+        let pow = 6;
+        assert_eq!(divide_pow_ten_trunc(uint, pow), BigUint::from(1_234u64))
+    }
+
+    #[test]
+    fn given_pow_zero_it_doesnt_modifies() {
+        let uint = BigUint::from(1_234_456_789u64);
+        let pow = 0;
+        assert_eq!(divide_pow_ten_trunc(uint.clone(), pow), uint)
+    }
+
+    proptest! {
+        #[test]
+        fn divide_pow_ten_trunc_doesnt_panic(s in "[0-9]+", p in any::<usize>()) {
+            let uint = BigUint::from_str(&s);
+            if let Ok(uint) = uint {
+                let _ = divide_pow_ten_trunc(uint, p);
+            }
+        }
+    }
+}

--- a/src/float_maths.rs
+++ b/src/float_maths.rs
@@ -17,10 +17,10 @@ pub fn truncate(float: f64, precision: u16) -> f64 {
     }
 }
 
-/// Multiple float by 10e`pow`, Returns as a BigUint. No data loss.
+/// Multiply float by 10e`pow`, Returns as a BigUint. No data loss.
 /// Errors if the float is negative.
 /// Errors if the result is a fraction.
-pub fn multiple_pow_ten(float: f64, pow: u16) -> anyhow::Result<BigUint> {
+pub fn multiply_pow_ten(float: f64, pow: u16) -> anyhow::Result<BigUint> {
     if float.is_sign_negative() {
         anyhow::bail!("Float is negative");
     }
@@ -107,7 +107,7 @@ mod tests {
         let pow = 6;
 
         assert_eq!(
-            multiple_pow_ten(float, pow).unwrap(),
+            multiply_pow_ten(float, pow).unwrap(),
             BigUint::from(123_456_789_000_000u64)
         )
     }
@@ -118,7 +118,7 @@ mod tests {
         let pow = 9;
 
         assert_eq!(
-            multiple_pow_ten(float, pow).unwrap(),
+            multiply_pow_ten(float, pow).unwrap(),
             BigUint::from(123_123_456_789u64)
         )
     }
@@ -129,7 +129,7 @@ mod tests {
         let pow = 12;
 
         assert_eq!(
-            multiple_pow_ten(float, pow).unwrap(),
+            multiply_pow_ten(float, pow).unwrap(),
             BigUint::from(123_123_456_789_000u64)
         )
     }
@@ -139,7 +139,7 @@ mod tests {
         let float = 123.123_456_789f64;
         let pow = 6;
 
-        assert!(multiple_pow_ten(float, pow).is_err(),)
+        assert!(multiply_pow_ten(float, pow).is_err(),)
     }
 
     #[test]
@@ -147,13 +147,13 @@ mod tests {
         let float = -123_456_789.0f64;
         let pow = 6;
 
-        assert!(multiple_pow_ten(float, pow).is_err(),)
+        assert!(multiply_pow_ten(float, pow).is_err(),)
     }
 
     proptest! {
         #[test]
         fn multiple_pow_ten_doesnt_panic(f in any::<f64>(), p in any::<u16>()) {
-            let _ = multiple_pow_ten(f, p);
+            let _ = multiply_pow_ten(f, p);
         }
     }
 

--- a/src/float_maths.rs
+++ b/src/float_maths.rs
@@ -187,10 +187,15 @@ mod tests {
         assert_eq!(divide_pow_ten_trunc(uint.clone(), pow), BigUint::zero())
     }
 
+    prop_compose! {
+        fn new_biguint()(s in "[0-9]+") -> anyhow::Result<BigUint> {
+            Ok(BigUint::from_str(&s)?)
+        }
+    }
+
     proptest! {
         #[test]
-        fn divide_pow_ten_trunc_doesnt_panic(s in "[0-9]+", p in any::<usize>()) {
-            let uint = BigUint::from_str(&s);
+        fn divide_pow_ten_trunc_doesnt_panic(uint in new_biguint(), p in any::<usize>()) {
             if let Ok(uint) = uint {
                 let _ = divide_pow_ten_trunc(uint, p);
             }

--- a/src/float_maths.rs
+++ b/src/float_maths.rs
@@ -177,14 +177,14 @@ mod tests {
     fn given_pow_greater_than_uint_it_truncates_to_zero_1() {
         let uint = BigUint::from(1_234_567_890u64);
         let pow = 10;
-        assert_eq!(divide_pow_ten_trunc(uint.clone(), pow), BigUint::zero())
+        assert_eq!(divide_pow_ten_trunc(uint, pow), BigUint::zero())
     }
 
     #[test]
     fn given_pow_greater_than_uint_it_truncates_to_zero_2() {
         let uint = BigUint::from(1_234_456_789u64);
         let pow = 11;
-        assert_eq!(divide_pow_ten_trunc(uint.clone(), pow), BigUint::zero())
+        assert_eq!(divide_pow_ten_trunc(uint, pow), BigUint::zero())
     }
 
     prop_compose! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,15 @@
 #![allow(dead_code)] // To be removed further down the line
 #![forbid(unsafe_code)]
 
+pub mod bitcoin;
 pub mod bitcoin_wallet;
 pub mod bitcoind;
+pub mod dai;
+pub mod float_maths;
 pub mod jsonrpc;
+pub mod ongoing_swaps;
+pub mod publish;
+pub mod rate;
 pub mod swap;
 
 lazy_static::lazy_static! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@
 #![allow(dead_code)] // To be removed further down the line
 #![forbid(unsafe_code)]
 
+use conquer_once::Lazy;
+
 pub mod bitcoin;
 pub mod bitcoin_wallet;
 pub mod bitcoind;
@@ -24,10 +26,8 @@ pub mod publish;
 pub mod rate;
 pub mod swap;
 
-lazy_static::lazy_static! {
-    pub static ref SECP: ::bitcoin::secp256k1::Secp256k1<::bitcoin::secp256k1::All> =
-        ::bitcoin::secp256k1::Secp256k1::new();
-}
+pub static SECP: Lazy<::bitcoin::secp256k1::Secp256k1<::bitcoin::secp256k1::All>> =
+    Lazy::new(::bitcoin::secp256k1::Secp256k1::new);
 
 #[cfg(all(test, feature = "test-docker"))]
 pub mod test_harness;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@
 #![forbid(unsafe_code)]
 // TODO: Add no unwrap policy
 
+use conquer_once::Lazy;
+
 mod bitcoin;
 mod bitcoin_wallet;
 mod bitcoind;
@@ -29,10 +31,8 @@ mod swap;
 #[cfg(all(test, feature = "test-docker"))]
 pub mod test_harness;
 
-lazy_static::lazy_static! {
-    pub static ref SECP: ::bitcoin::secp256k1::Secp256k1<::bitcoin::secp256k1::All> =
-        ::bitcoin::secp256k1::Secp256k1::new();
-}
+pub static SECP: Lazy<::bitcoin::secp256k1::Secp256k1<::bitcoin::secp256k1::All>> =
+    Lazy::new(::bitcoin::secp256k1::Secp256k1::new);
 
 fn main() {
     println!("Hello, world!");

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,13 +12,19 @@
 )]
 #![allow(dead_code)] // To be removed further down the line
 #![forbid(unsafe_code)]
+// TODO: Add no unwrap policy
 
+mod bitcoin;
 mod bitcoin_wallet;
 mod bitcoind;
+mod dai;
+mod float_maths;
 mod jsonrpc;
 mod markets;
 mod ongoing_swaps;
 mod publish;
+mod rate;
+mod swap;
 
 #[cfg(all(test, feature = "test-docker"))]
 pub mod test_harness;

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -134,8 +134,7 @@ mod tests {
         let rate = Rate::from_f64(1.0).unwrap();
 
         let order =
-            new_dai_bitcoin_order(wallet, book, btc(100.0), rate, Spread::new(0.0).unwrap())
-                .unwrap();
+            new_dai_bitcoin_order(wallet, book, btc(100.0), rate, Spread::new(0).unwrap()).unwrap();
 
         assert_eq!(order.sell_amount, btc(10.0));
     }
@@ -147,8 +146,7 @@ mod tests {
         let rate = Rate::from_f64(1.0).unwrap();
 
         let order =
-            new_dai_bitcoin_order(wallet, book, btc(100.0), rate, Spread::new(0.0).unwrap())
-                .unwrap();
+            new_dai_bitcoin_order(wallet, book, btc(100.0), rate, Spread::new(0).unwrap()).unwrap();
 
         assert_eq!(order.sell_amount, btc(8.0));
     }
@@ -160,7 +158,7 @@ mod tests {
         let rate = Rate::from_f64(1.0).unwrap();
 
         let order =
-            new_dai_bitcoin_order(wallet, book, btc(2.0), rate, Spread::new(0.0).unwrap()).unwrap();
+            new_dai_bitcoin_order(wallet, book, btc(2.0), rate, Spread::new(0).unwrap()).unwrap();
 
         assert_eq!(order.sell_amount, btc(2.0));
     }
@@ -173,7 +171,7 @@ mod tests {
 
         let rate = Rate::from_f64(1.0).unwrap();
         let order =
-            new_dai_bitcoin_order(wallet, book, btc(2.0), rate, Spread::new(0.0).unwrap()).unwrap();
+            new_dai_bitcoin_order(wallet, book, btc(2.0), rate, Spread::new(0).unwrap()).unwrap();
 
         assert_eq!(order.sell_amount, btc(1.0));
     }
@@ -184,9 +182,8 @@ mod tests {
         let book = Book::new(btc(50.0));
         let rate = Rate::from_f64(0.1).unwrap();
 
-        let order =
-            new_dai_bitcoin_order(wallet, book, btc(9999.0), rate, Spread::new(0.0).unwrap())
-                .unwrap();
+        let order = new_dai_bitcoin_order(wallet, book, btc(9999.0), rate, Spread::new(0).unwrap())
+            .unwrap();
 
         // 1 Sell => 0.1 Buy
         // 1000 Sell => 100 Buy
@@ -195,9 +192,8 @@ mod tests {
 
         let rate = Rate::from_f64(10.0).unwrap();
 
-        let order =
-            new_dai_bitcoin_order(wallet, book, btc(9999.0), rate, Spread::new(0.0).unwrap())
-                .unwrap();
+        let order = new_dai_bitcoin_order(wallet, book, btc(9999.0), rate, Spread::new(0).unwrap())
+            .unwrap();
 
         assert_eq!(order.sell_amount, btc(1000.0));
         assert_eq!(order.buy_amount, dai(10_000.0));
@@ -208,7 +204,7 @@ mod tests {
         let wallet = Wallet::new(btc(1051.0), btc(1.0));
         let book = Book::new(btc(50.0));
         let rate = Rate::from_f64(0.1).unwrap();
-        let spread = Spread::new(3.0).unwrap();
+        let spread = Spread::new(300).unwrap();
 
         let order = new_dai_bitcoin_order(wallet, book, btc(9999.0), rate, spread).unwrap();
 

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -131,8 +131,8 @@ mod tests {
     fn given_a_balance_return_order_selling_full_balance() {
         let wallet = Wallet::new(btc(10.0), btc(0.0));
         let book = Book::new(btc(0.0));
-        let rate = Rate::from_f64(1.0).unwrap();
 
+        let rate = Rate::from_f64(1.0).unwrap();
         let order =
             new_dai_bitcoin_order(wallet, book, btc(100.0), rate, Spread::new(0).unwrap()).unwrap();
 
@@ -143,8 +143,8 @@ mod tests {
     fn given_a_balance_and_locked_funds_return_order_selling_available_balance() {
         let wallet = Wallet::new(btc(10.0), btc(0.0));
         let book = Book::new(btc(2.0));
-        let rate = Rate::from_f64(1.0).unwrap();
 
+        let rate = Rate::from_f64(1.0).unwrap();
         let order =
             new_dai_bitcoin_order(wallet, book, btc(100.0), rate, Spread::new(0).unwrap()).unwrap();
 
@@ -155,8 +155,8 @@ mod tests {
     fn given_an_available_balance_and_a_max_amount_sell_min_of_either() {
         let wallet = Wallet::new(btc(10.0), btc(0.0));
         let book = Book::new(btc(2.0));
-        let rate = Rate::from_f64(1.0).unwrap();
 
+        let rate = Rate::from_f64(1.0).unwrap();
         let order =
             new_dai_bitcoin_order(wallet, book, btc(2.0), rate, Spread::new(0).unwrap()).unwrap();
 
@@ -166,7 +166,6 @@ mod tests {
     #[test]
     fn given_an_available_balance_and_fees_sell_balance_minus_fees() {
         let wallet = Wallet::new(btc(10.0), btc(1.0));
-
         let book = Book::new(btc(2.0));
 
         let rate = Rate::from_f64(1.0).unwrap();
@@ -180,10 +179,11 @@ mod tests {
     fn given_a_rate_return_order_with_both_amounts() {
         let wallet = Wallet::new(btc(1051.0), btc(1.0));
         let book = Book::new(btc(50.0));
+        let spread = Spread::new(0).unwrap();
+
         let rate = Rate::from_f64(0.1).unwrap();
 
-        let order = new_dai_bitcoin_order(wallet, book, btc(9999.0), rate, Spread::new(0).unwrap())
-            .unwrap();
+        let order = new_dai_bitcoin_order(wallet, book, btc(9999.0), rate, spread).unwrap();
 
         // 1 Sell => 0.1 Buy
         // 1000 Sell => 100 Buy
@@ -192,8 +192,7 @@ mod tests {
 
         let rate = Rate::from_f64(10.0).unwrap();
 
-        let order = new_dai_bitcoin_order(wallet, book, btc(9999.0), rate, Spread::new(0).unwrap())
-            .unwrap();
+        let order = new_dai_bitcoin_order(wallet, book, btc(9999.0), rate, spread).unwrap();
 
         assert_eq!(order.sell_amount, btc(1000.0));
         assert_eq!(order.buy_amount, dai(10_000.0));

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -20,14 +20,6 @@ struct DaiBitcoinOrder {
     pub sell_amount: bitcoin::Amount,
 }
 
-/// Allow to know the worth of self in a different asset using
-/// The given conversion rate.
-/// Truncation may be done during the conversion to allow a result in the smallest
-/// supported unit of `Asset`.
-pub trait WorthIn<Asset> {
-    fn worth_in(&self, rate: Rate) -> anyhow::Result<Asset>;
-}
-
 /// The maker creates an order that defines how much he wants to buy for the amount he is selling.
 /// order's buy amount = what the maker wants from a taker
 /// order's sell amount = what the maker is offering to a taker
@@ -60,7 +52,7 @@ where
 
     let rate = spread.apply(mid_market_rate)?;
 
-    let buy_amount = sell_amount.worth_in(rate).unwrap();
+    let buy_amount = sell_amount.worth_in(rate);
 
     Ok(DaiBitcoinOrder {
         sell_amount,

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -22,9 +22,8 @@ struct DaiBitcoinOrder {
 
 /// Allow to know the worth of self in a different asset using
 /// The given conversion rate.
-/// MAX_PRECISION_EXP is the maximum precision allowed (number of digits after
-/// the comma) for the rate passed in. This is to ensure that no precision is loss
-/// or truncation done when doing the conversion.
+/// Truncation may be done during the conversion to allow a result in the smallest
+/// supported unit of `Asset`.
 pub trait WorthIn<Asset> {
     fn worth_in(&self, rate: Rate) -> anyhow::Result<Asset>;
 }

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -72,6 +72,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::convert::TryFrom;
 
     #[derive(Copy, Clone)]
     struct Book {
@@ -132,7 +133,7 @@ mod tests {
         let wallet = Wallet::new(btc(10.0), btc(0.0));
         let book = Book::new(btc(0.0));
 
-        let rate = Rate::from_f64(1.0).unwrap();
+        let rate = Rate::try_from(1.0).unwrap();
         let order =
             new_dai_bitcoin_order(wallet, book, btc(100.0), rate, Spread::new(0).unwrap()).unwrap();
 
@@ -144,7 +145,7 @@ mod tests {
         let wallet = Wallet::new(btc(10.0), btc(0.0));
         let book = Book::new(btc(2.0));
 
-        let rate = Rate::from_f64(1.0).unwrap();
+        let rate = Rate::try_from(1.0).unwrap();
         let order =
             new_dai_bitcoin_order(wallet, book, btc(100.0), rate, Spread::new(0).unwrap()).unwrap();
 
@@ -156,7 +157,7 @@ mod tests {
         let wallet = Wallet::new(btc(10.0), btc(0.0));
         let book = Book::new(btc(2.0));
 
-        let rate = Rate::from_f64(1.0).unwrap();
+        let rate = Rate::try_from(1.0).unwrap();
         let order =
             new_dai_bitcoin_order(wallet, book, btc(2.0), rate, Spread::new(0).unwrap()).unwrap();
 
@@ -168,7 +169,7 @@ mod tests {
         let wallet = Wallet::new(btc(10.0), btc(1.0));
         let book = Book::new(btc(2.0));
 
-        let rate = Rate::from_f64(1.0).unwrap();
+        let rate = Rate::try_from(1.0).unwrap();
         let order =
             new_dai_bitcoin_order(wallet, book, btc(2.0), rate, Spread::new(0).unwrap()).unwrap();
 
@@ -181,7 +182,7 @@ mod tests {
         let book = Book::new(btc(50.0));
         let spread = Spread::new(0).unwrap();
 
-        let rate = Rate::from_f64(0.1).unwrap();
+        let rate = Rate::try_from(0.1).unwrap();
 
         let order = new_dai_bitcoin_order(wallet, book, btc(9999.0), rate, spread).unwrap();
 
@@ -190,7 +191,7 @@ mod tests {
         assert_eq!(order.sell_amount, btc(1000.0));
         assert_eq!(order.buy_amount, dai(100.0));
 
-        let rate = Rate::from_f64(10.0).unwrap();
+        let rate = Rate::try_from(10.0).unwrap();
 
         let order = new_dai_bitcoin_order(wallet, book, btc(9999.0), rate, spread).unwrap();
 
@@ -202,7 +203,7 @@ mod tests {
     fn given_a_rate_and_spread_return_order_with_both_amounts() {
         let wallet = Wallet::new(btc(1051.0), btc(1.0));
         let book = Book::new(btc(50.0));
-        let rate = Rate::from_f64(0.1).unwrap();
+        let rate = Rate::try_from(0.1).unwrap();
         let spread = Spread::new(300).unwrap();
 
         let order = new_dai_bitcoin_order(wallet, book, btc(9999.0), rate, spread).unwrap();

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -71,7 +71,6 @@ impl TryFrom<f64> for Rate {
 
 /// Spread: percentage to be added on top of a rate or amount with
 /// a maximum precision of 2 decimals
-// 0 is the rate * 100.
 #[derive(Clone, Copy, Debug)]
 pub struct Spread(u16);
 

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -89,7 +89,7 @@ impl Rate {
 /// a maximum precision of 2 decimals
 // 0 is the rate * 100.
 #[derive(Clone, Copy, Debug)]
-pub struct Spread(u32);
+pub struct Spread(u16);
 
 impl Spread {
     /// Input is the spread in percent: 5.0 is 5%
@@ -107,7 +107,7 @@ impl Spread {
         match decimal_index {
             None => {
                 if spread.len() <= 2 || spread == "100" {
-                    let spread = u32::from_str(&spread).expect("an integer");
+                    let spread = u16::from_str(&spread).expect("an integer");
                     Ok(Spread(spread * 100))
                 } else {
                     anyhow::bail!("Spread value is too high, it should be between 0 and 100.")
@@ -122,8 +122,8 @@ impl Spread {
                     spread.truncate(spread.len() - 1);
                     let integer = spread;
                     if integer.len() <= 2 || integer == "100" {
-                        let integer = u32::from_str(&integer).expect("an integer");
-                        let mantissa = u32::from_str(&mantissa).expect("an integer");
+                        let integer = u16::from_str(&integer).expect("an integer");
+                        let mantissa = u16::from_str(&mantissa).expect("an integer");
                         Ok(Spread(integer * 100 + mantissa))
                     } else {
                         anyhow::bail!("Spread value is too high, it should be between 0 and 100.")

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -1,34 +1,29 @@
-use std::convert::TryFrom;
+use anyhow::bail;
+use num::{BigUint, Integer, ToPrimitive};
+use std::iter::FromIterator;
 use std::str::FromStr;
 
 /// Represent a rate. Note this is designed to support Bitcoin/Dai buy and sell rates (Bitcoin being in the range of 10k-100kDai)
-// The rate is equal to integer * 10e-inv_dec_exp
+/// A rate has a maximum precision of 9 digits after the decimal
+// rate = self.0 * 10e-9
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Rate {
-    integer: u32,
-    inv_dec_exp: usize,
-}
+pub struct Rate(u64);
 
 impl Rate {
-    const MAX_PRECISION: usize = 9;
+    pub const PRECISION: u16 = 9;
+    const MAX_RATE: u64 = (u64::MAX / 10) ^ 9;
 
-    pub fn integer(&self) -> u32 {
-        self.integer
+    /// integer = rate * 10ePRECISION
+    pub fn new(integer: u64) -> anyhow::Result<Self> {
+        if integer > Self::MAX_RATE {
+            bail!("Rate is larger than supported");
+        }
+        Ok(Rate(integer))
     }
 
-    pub fn inverse_decimal_exponent(&self) -> usize {
-        self.inv_dec_exp
-    }
-
-    pub fn new(integer: u64, inverse_decimal_exponent: usize) -> anyhow::Result<Self> {
-        let (integer, inv_dec_exp) = Rate::reduce(integer, inverse_decimal_exponent);
-
-        let integer =
-            u32::try_from(integer).map_err(|_| anyhow::anyhow!("Value is unexpectedly large."))?;
-        Ok(Rate {
-            integer,
-            inv_dec_exp,
-        })
+    /// integer = rate * 10ePRECISION
+    pub fn integer(&self) -> u64 {
+        self.0
     }
 
     pub fn from_f64(rate: f64) -> anyhow::Result<Rate> {
@@ -42,29 +37,28 @@ impl Rate {
 
         let mut rate = rate.to_string();
         let decimal_index = rate.find('.');
-        match decimal_index {
-            None => {
-                let rate = u64::from_str(&rate)
-                    .map_err(|_| anyhow::anyhow!("Rate is unexpectedly large."))?;
-                Rate::new(rate, 0)
-            }
+        let mantissa = match decimal_index {
+            None => String::new(),
             Some(decimal_index) => {
                 let mantissa = rate.split_off(decimal_index + 1);
-                if mantissa.len() > Self::MAX_PRECISION {
+                if mantissa.len() > Self::PRECISION as usize {
                     anyhow::bail!("Precision of the rate is too high.")
                 } else {
                     // Removes the trailing decimal point
                     rate.truncate(rate.len() - 1);
-                    let integer = rate;
-
-                    let inv_dec_exp = mantissa.len();
-
-                    let integer = u64::from_str(&format!("{}{}", integer, mantissa))
-                        .map_err(|_| anyhow::anyhow!("Rate is unexpectedly large"))?;
-                    Rate::new(integer, inv_dec_exp)
+                    mantissa
                 }
             }
-        }
+        };
+
+        let mantissa_length = mantissa.len();
+        let integer = rate;
+
+        let zeros = vec!['0'].repeat(Self::PRECISION as usize - mantissa_length);
+        let zeros = String::from_iter(zeros.into_iter());
+        let integer = u64::from_str(&format!("{}{}{}", integer, mantissa, zeros))
+            .map_err(|_| anyhow::anyhow!("Rate is unexpectedly large"))?;
+        Rate::new(integer)
     }
 
     /// If the integer part ends with 0 and the inverse_decimal_exponent is not null
@@ -106,10 +100,14 @@ impl Spread {
     }
 
     pub fn apply(&self, rate: Rate) -> anyhow::Result<Rate> {
-        // Goes to u64 to avoid overflow until it's reduced.
-        let integer = rate.integer as u64 * (10_000 + self.0 as u64);
-        let inv_dec_exp = rate.inv_dec_exp + 4;
-        Rate::new(integer, inv_dec_exp)
+        let ten_thousand = BigUint::from(10_000u16);
+        let integer = BigUint::from(rate.integer()) * (ten_thousand.clone() + self.0);
+        // Now divide by 10e4 because of the spread
+        let (rate, _remainder) = integer.div_rem(&ten_thousand);
+        let rate = rate
+            .to_u64()
+            .ok_or_else(|| anyhow::anyhow!("Result is unexpectedly large"))?;
+        Rate::new(rate)
     }
 }
 
@@ -117,6 +115,20 @@ impl Spread {
 mod tests {
     use super::*;
     use proptest::prelude::*;
+
+    #[test]
+    fn from_f64_and_new_matches_1() {
+        let rate_from_f64 = Rate::from_f64(123.456).unwrap();
+        let rate_new = Rate::new(123_456_000_000).unwrap();
+        assert_eq!(rate_from_f64, rate_new);
+    }
+
+    #[test]
+    fn from_f64_and_new_matches_2() {
+        let rate_from_f64 = Rate::from_f64(10.0).unwrap();
+        let rate_new = Rate::new(10_000_000_000).unwrap();
+        assert_eq!(rate_from_f64, rate_new);
+    }
 
     #[test]
     fn rate_error_on_negative_rate() {
@@ -142,13 +154,7 @@ mod tests {
         let rate = Rate::from_f64(25.0).unwrap();
         let new_rate = spread.apply(rate).unwrap();
 
-        assert_eq!(
-            new_rate,
-            Rate {
-                integer: 30,
-                inv_dec_exp: 0
-            }
-        )
+        assert_eq!(new_rate, Rate::from_f64(30.0).unwrap())
     }
 
     #[test]
@@ -157,13 +163,15 @@ mod tests {
         let rate = Rate::from_f64(25.0).unwrap();
         let new_rate = spread.apply(rate).unwrap();
 
-        assert_eq!(
-            new_rate,
-            Rate {
-                integer: 30,
-                inv_dec_exp: 0
-            }
-        )
+        assert_eq!(new_rate, Rate::from_f64(30.0).unwrap())
+    }
+
+    #[test]
+    fn apply_spread_zero_doesnt_change_rate() {
+        let spread = Spread::new(0).unwrap();
+        let rate = Rate::from_f64(123456.789).unwrap();
+        let res = spread.apply(rate).unwrap();
+        assert_eq!(rate, res);
     }
 
     proptest! {
@@ -175,8 +183,8 @@ mod tests {
 
     proptest! {
         #[test]
-        fn rate_new_doesnt_panic(i in any::<u64>(), u in any::<usize>()) {
-            let _ = Rate::new(i, u);
+        fn rate_new_doesnt_panic(i in any::<u64>()) {
+            let _ = Rate::new(i);
         }
     }
 
@@ -194,6 +202,18 @@ mod tests {
             let rate = Rate::from_f64(r);
             if let (Ok(rate), Ok(spread)) = (rate, spread) {
                 let _ = spread.apply(rate);
+            }
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn spread_zero_doesnt_change_rate(r in any::<f64>()) {
+            let spread = Spread::new(0).unwrap();
+            let rate = Rate::from_f64(r);
+            if let Ok(rate) = rate {
+                let res = spread.apply(rate).unwrap();
+                assert_eq!(res, rate)
             }
         }
     }

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context};
+use anyhow::Context;
 use num::{BigUint, Integer, ToPrimitive};
 use std::convert::TryFrom;
 use std::iter::FromIterator;
@@ -51,10 +51,9 @@ impl TryFrom<f64> for Rate {
                         "Precision of the rate is too high (max is {}).",
                         Self::PRECISION
                     ))
-                } else {
-                    rate.truncate(rate.len() - 1); // Removes the trailing decimal point
-                    mantissa
                 }
+                rate.truncate(rate.len() - 1); // Removes the trailing decimal point
+                mantissa
             }
         };
 

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -1,4 +1,4 @@
-use anyhow::bail;
+use anyhow::{bail, Context};
 use num::{BigUint, Integer, ToPrimitive};
 use std::iter::FromIterator;
 use std::str::FromStr;
@@ -57,7 +57,7 @@ impl Rate {
         let zeros = vec!['0'].repeat(Self::PRECISION as usize - mantissa_length);
         let zeros = String::from_iter(zeros.into_iter());
         let integer = u64::from_str(&format!("{}{}{}", integer, mantissa, zeros))
-            .map_err(|_| anyhow::anyhow!("Rate is unexpectedly large"))?;
+            .context("Rate is unexpectedly large")?;
         Rate::new(integer)
     }
 

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -60,23 +60,6 @@ impl Rate {
             .context("Rate is unexpectedly large")?;
         Rate::new(integer)
     }
-
-    /// If the integer part ends with 0 and the inverse_decimal_exponent is not null
-    /// then we can reduce the representation by removing zero and decrementing the inverse
-    /// exponent. For example:
-    /// Rate { integer: 1000, inv_dec_exp: 1 } becomes
-    /// Rate { integer: 100, inv_dec_exp: 0 }.
-    fn reduce(integer: u64, inv_dec_exp: usize) -> (u64, usize) {
-        let mut integer_str = integer.to_string();
-        if integer_str.len() > 1 && integer_str.ends_with('0') && inv_dec_exp != 0 {
-            integer_str.truncate(integer_str.len() - 1);
-            let inv_dec_exp = inv_dec_exp - 1;
-            let integer = u64::from_str(&integer_str).expect("an integer");
-            Rate::reduce(integer, inv_dec_exp)
-        } else {
-            (integer, inv_dec_exp)
-        }
-    }
 }
 
 /// Spread: percentage to be added on top of a rate or amount with

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -165,8 +165,8 @@ mod tests {
 
     proptest! {
         #[test]
-        fn spread_new_doesnt_panic(f in any::<u16>()) {
-            let _ = Spread::new(f);
+        fn spread_new_doesnt_panic(s in any::<u16>()) {
+            let _ = Spread::new(s);
         }
     }
 
@@ -184,11 +184,21 @@ mod tests {
         }
     }
 
+    prop_compose! {
+        fn new_spread()(s in any::<u16>()) -> anyhow::Result<Spread> {
+            Spread::new(s)
+        }
+    }
+
+    prop_compose! {
+        fn new_rate()(f in any::<f64>()) -> anyhow::Result<Rate> {
+            Rate::try_from(f)
+        }
+    }
+
     proptest! {
         #[test]
-        fn spread_apply_doesnt_panic(s in any::<u16>(), r in any::<f64>()) {
-            let spread = Spread::new(s);
-            let rate = Rate::try_from(r);
+        fn spread_apply_doesnt_panic(rate in new_rate(), spread in new_spread()) {
             if let (Ok(rate), Ok(spread)) = (rate, spread) {
                 let _ = spread.apply(rate);
             }
@@ -197,9 +207,8 @@ mod tests {
 
     proptest! {
         #[test]
-        fn spread_zero_doesnt_change_rate(r in any::<f64>()) {
+        fn spread_zero_doesnt_change_rate(rate in new_rate()) {
             let spread = Spread::new(0).unwrap();
-            let rate = Rate::try_from(r);
             if let Ok(rate) = rate {
                 let res = spread.apply(rate).unwrap();
                 assert_eq!(res, rate)

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -70,17 +70,17 @@ impl TryFrom<f64> for Rate {
 pub struct Spread(u16);
 
 impl Spread {
-    /// Input is the spread in percent, with 2 digits after the decimal point:
-    /// 5% => 500
-    /// 23.14% => 2314
+    /// Input is the spread in permyriad (per ten thousand):
+    /// 5% => 500 permyriad
+    /// 23.14% => 2314 permyriad
     /// 0.001% => Not allowed
     /// 200% => Not allowed
-    pub fn new(spread: u16) -> anyhow::Result<Spread> {
-        if spread > 10000 {
+    pub fn new(permyriad: u16) -> anyhow::Result<Spread> {
+        if permyriad > 10000 {
             anyhow::bail!("Spread must be between 0% and 100%");
         }
 
-        Ok(Spread(spread))
+        Ok(Spread(permyriad))
     }
 
     pub fn apply(&self, rate: Rate) -> anyhow::Result<Rate> {

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -22,8 +22,8 @@ impl Rate {
     }
 
     /// integer = rate * 10ePRECISION
-    pub fn integer(&self) -> u64 {
-        self.0
+    pub fn integer(&self) -> BigUint {
+        BigUint::from(self.0)
     }
 
     pub fn from_f64(rate: f64) -> anyhow::Result<Rate> {
@@ -101,7 +101,7 @@ impl Spread {
 
     pub fn apply(&self, rate: Rate) -> anyhow::Result<Rate> {
         let ten_thousand = BigUint::from(10_000u16);
-        let integer = BigUint::from(rate.integer()) * (ten_thousand.clone() + self.0);
+        let integer = rate.integer() * (ten_thousand.clone() + self.0);
         // Now divide by 10e4 because of the spread
         let (rate, _remainder) = integer.div_rem(&ten_thousand);
         let rate = rate

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -1,0 +1,210 @@
+use std::convert::TryFrom;
+use std::str::FromStr;
+
+/// Represent a rate. Note this is designed to support Bitcoin/Dai buy and sell rates (Bitcoin being in the range of 10k-100kDai)
+// The rate is equal to integer * 10e-inv_dec_exp
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Rate {
+    integer: u32,
+    inv_dec_exp: usize,
+}
+
+impl Rate {
+    const MAX_PRECISION: usize = 9;
+
+    pub fn integer(&self) -> u32 {
+        self.integer
+    }
+
+    pub fn inverse_decimal_exponent(&self) -> usize {
+        self.inv_dec_exp
+    }
+
+    pub fn new(integer: u64, inverse_decimal_exponent: usize) -> anyhow::Result<Self> {
+        let (integer, inv_dec_exp) = Rate::reduce(integer, inverse_decimal_exponent);
+
+        let integer =
+            u32::try_from(integer).map_err(|_| anyhow::anyhow!("Value is unexpectedly large."))?;
+        Ok(Rate {
+            integer,
+            inv_dec_exp,
+        })
+    }
+
+    pub fn from_f64(rate: f64) -> anyhow::Result<Rate> {
+        if rate.is_sign_negative() {
+            anyhow::bail!("Spread must be positive");
+        }
+
+        if !rate.is_finite() {
+            anyhow::bail!("Spread must be finite")
+        }
+
+        let mut rate = rate.to_string();
+        let decimal_index = rate.find('.');
+        match decimal_index {
+            None => {
+                let rate = u64::from_str(&rate)
+                    .map_err(|_| anyhow::anyhow!("Rate is unexpectedly large."))?;
+                Rate::new(rate, 0)
+            }
+            Some(decimal_index) => {
+                let mantissa = rate.split_off(decimal_index + 1);
+                if mantissa.len() > Self::MAX_PRECISION {
+                    anyhow::bail!("Precision of the rate is too high.")
+                } else {
+                    // Removes the trailing decimal point
+                    rate.truncate(rate.len() - 1);
+                    let integer = rate;
+
+                    let inv_dec_exp = mantissa.len();
+
+                    let integer = u64::from_str(&format!("{}{}", integer, mantissa))
+                        .map_err(|_| anyhow::anyhow!("Rate is unexpectedly large"))?;
+                    Rate::new(integer, inv_dec_exp)
+                }
+            }
+        }
+    }
+
+    /// If the integer part ends with 0 and the inverse_decimal_exponent is not null
+    /// then we can reduce the representation by removing zero and decrementing the inverse
+    /// exponent. For example:
+    /// Rate { integer: 1000, inv_dec_exp: 1 } becomes
+    /// Rate { integer: 100, inv_dec_exp: 0 }.
+    fn reduce(integer: u64, inv_dec_exp: usize) -> (u64, usize) {
+        let mut integer_str = integer.to_string();
+        if integer_str.len() > 1 && integer_str.ends_with('0') && inv_dec_exp != 0 {
+            integer_str.truncate(integer_str.len() - 1);
+            let inv_dec_exp = inv_dec_exp - 1;
+            let integer = u64::from_str(&integer_str).expect("an integer");
+            Rate::reduce(integer, inv_dec_exp)
+        } else {
+            (integer, inv_dec_exp)
+        }
+    }
+}
+
+/// Spread: percentage to be added on top of a rate or amount with
+/// a maximum precision of 2 decimals
+// 0 is the rate * 100.
+#[derive(Clone, Copy, Debug)]
+pub struct Spread(u32);
+
+impl Spread {
+    /// Input is the spread in percent: 5.0 is 5%
+    pub fn new(spread: f64) -> anyhow::Result<Spread> {
+        if spread.is_sign_negative() {
+            anyhow::bail!("Spread must be positive");
+        }
+
+        if !spread.is_finite() {
+            anyhow::bail!("Spread must be finite")
+        }
+
+        let mut spread = spread.to_string();
+        let decimal_index = spread.find('.');
+        match decimal_index {
+            None => {
+                if spread.len() <= 2 || spread == "100" {
+                    let spread = u32::from_str(&spread).expect("an integer");
+                    Ok(Spread(spread * 100))
+                } else {
+                    anyhow::bail!("Spread value is too high, it should be between 0 and 100.")
+                }
+            }
+            Some(decimal_index) => {
+                let mantissa = spread.split_off(decimal_index + 1);
+                if mantissa.len() > 2 {
+                    anyhow::bail!("Precision of the rate is too high, maximum allow is 2 digits after the decimal point.")
+                } else {
+                    // Removes the trailing decimal point
+                    spread.truncate(spread.len() - 1);
+                    let integer = spread;
+                    if integer.len() <= 2 || integer == "100" {
+                        let integer = u32::from_str(&integer).expect("an integer");
+                        let mantissa = u32::from_str(&mantissa).expect("an integer");
+                        Ok(Spread(integer * 100 + mantissa))
+                    } else {
+                        anyhow::bail!("Spread value is too high, it should be between 0 and 100.")
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn apply(&self, rate: Rate) -> anyhow::Result<Rate> {
+        // Goes to u64 to avoid overflow until it's reduced.
+        let integer = rate.integer as u64 * (10_000 + self.0 as u64);
+        let inv_dec_exp = rate.inv_dec_exp + 4;
+        Rate::new(integer, inv_dec_exp)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn apply_spread_20() {
+        let spread = Spread::new(20.0).unwrap();
+        let rate = Rate::from_f64(25.0).unwrap();
+        let new_rate = spread.apply(rate).unwrap();
+
+        assert_eq!(
+            new_rate,
+            Rate {
+                integer: 30,
+                inv_dec_exp: 0
+            }
+        )
+    }
+
+    #[test]
+    fn apply_spread_3() {
+        let spread = Spread::new(20.0).unwrap();
+        let rate = Rate::from_f64(25.0).unwrap();
+        let new_rate = spread.apply(rate).unwrap();
+
+        assert_eq!(
+            new_rate,
+            Rate {
+                integer: 30,
+                inv_dec_exp: 0
+            }
+        )
+    }
+
+    proptest! {
+        #[test]
+        fn spread_new_doesnt_panic(f in any::<f64>()) {
+            let _ = Spread::new(f);
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn rate_new_doesnt_panic(i in any::<u64>(), u in any::<usize>()) {
+            let _ = Rate::new(i, u);
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn rate_from_f64_doesnt_panic(f in any::<f64>()) {
+            let _ = Rate::from_f64(f);
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn spread_apply_doesnt_panic(s in any::<f64>(), r in any::<f64>()) {
+            let spread = Spread::new(s);
+            let rate = Rate::from_f64(r);
+            if let (Ok(rate), Ok(spread)) = (rate, spread) {
+                let _ = spread.apply(rate);
+            }
+        }
+    }
+}

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -12,13 +12,9 @@ pub struct Rate(u64);
 
 impl Rate {
     pub const PRECISION: u16 = 9;
-    const MAX_RATE: u64 = (u64::MAX / 10) ^ 9;
 
     /// integer = rate * 10ePRECISION
     pub fn new(integer: u64) -> anyhow::Result<Self> {
-        if integer > Self::MAX_RATE {
-            bail!("Rate is larger than supported");
-        }
         Ok(Rate(integer))
     }
 

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -14,8 +14,8 @@ impl Rate {
     pub const PRECISION: u16 = 9;
 
     /// integer = rate * 10ePRECISION
-    pub fn new(integer: u64) -> anyhow::Result<Self> {
-        Ok(Rate(integer))
+    pub fn new(integer: u64) -> Self {
+        Rate(integer)
     }
 
     /// integer = rate * 10ePRECISION
@@ -60,7 +60,7 @@ impl TryFrom<f64> for Rate {
         let zeros = String::from_iter(zeros.into_iter());
         let integer = u64::from_str(&format!("{}{}{}", integer, mantissa, zeros))
             .context("Rate is unexpectedly large")?;
-        Rate::new(integer)
+        Ok(Rate::new(integer))
     }
 }
 
@@ -91,7 +91,7 @@ impl Spread {
         let rate = rate
             .to_u64()
             .ok_or_else(|| anyhow::anyhow!("Result is unexpectedly large"))?;
-        Rate::new(rate)
+        Ok(Rate::new(rate))
     }
 }
 
@@ -103,14 +103,14 @@ mod tests {
     #[test]
     fn from_f64_and_new_matches_1() {
         let rate_from_f64 = Rate::try_from(123.456).unwrap();
-        let rate_new = Rate::new(123_456_000_000).unwrap();
+        let rate_new = Rate::new(123_456_000_000);
         assert_eq!(rate_from_f64, rate_new);
     }
 
     #[test]
     fn from_f64_and_new_matches_2() {
         let rate_from_f64 = Rate::try_from(10.0).unwrap();
-        let rate_new = Rate::new(10_000_000_000).unwrap();
+        let rate_new = Rate::new(10_000_000_000);
         assert_eq!(rate_from_f64, rate_new);
     }
 


### PR DESCRIPTION
Remove any calculation that relies on floating point representation of a number.

I attempted to provide comments to explain what is going on. Feel free to claim more explanations/clarifications.

Everything that looks like it could panic or overflow is property tested, let me know if I missed something.

I also attempted to be smart in the usage of the primitives, do not hesitate to ask why a given primitive is used where.

Finally, `dai::Amount::from_dai` takes a `f64` input. I am not sure this is the right choice and I hesitated to just accept a string slice. Let me know your thoughts.