### PR TITLE
Return our own bitcoin Amount as wallet balance

### DIFF
--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -54,6 +54,12 @@ impl std::ops::Sub for Amount {
     }
 }
 
+impl From<::bitcoin::Amount> for Amount {
+    fn from(amount: ::bitcoin::Amount) -> Self {
+        Amount { 0: amount }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/bitcoin_wallet.rs
+++ b/src/bitcoin_wallet.rs
@@ -1,3 +1,4 @@
+use crate::bitcoin::Amount;
 use crate::bitcoind;
 use crate::bitcoind::WalletInfoResponse;
 use crate::seed::Seed;
@@ -5,7 +6,7 @@ use ::bitcoin::hash_types::PubkeyHash;
 use ::bitcoin::hashes::Hash;
 use ::bitcoin::Address;
 use ::bitcoin::Network;
-use bitcoin::{Amount, PrivateKey};
+use bitcoin::PrivateKey;
 use reqwest::Url;
 
 struct Wallet {
@@ -71,6 +72,7 @@ impl Wallet {
         self.bitcoind_client
             .get_balance(&self.name, None, None, None)
             .await
+            .map(|amount| amount.into())
     }
 
     /// Returns the private key in wif format, this allows the user to import the wallet in a


### PR DESCRIPTION
I left the bitcoind impl to use the bitcoin library's Amount because that seems cleaner.

Did not see this problem tackled yet in another PR so I thought I create a quick patch. Feel free to close and link to other PR if we already tackle this.