### PR TITLE
Add db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,6 +630,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d375c433320f6c5057ae04a04376eef4d04ce2801448cf8863a78da99107be4"
 
 [[package]]
+name = "crc32fast"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+dependencies = [
+ "autocfg 1.0.0",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "maybe-uninit",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +957,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,6 +1100,15 @@ dependencies = [
  "futures",
  "memchr",
  "pin-project",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1762,6 +1805,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
+name = "memoffset"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
+dependencies = [
+ "autocfg 1.0.0",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,10 +1951,12 @@ dependencies = [
  "serde-hex",
  "serde_json",
  "sha3 0.9.1",
+ "sled",
  "spectral",
  "structopt",
  "strum",
  "strum_macros",
+ "tempdir",
  "testcontainers",
  "thiserror",
  "tiny-bip39",
@@ -3244,6 +3298,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
+name = "sled"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdad3dc85d888056d3bd9954ffdf22d8a22701b6cd3aca4f6df4c436111898c4"
+dependencies = [
+ "backtrace",
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot 0.10.2",
+]
+
+[[package]]
 name = "smallvec"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3435,6 +3506,16 @@ dependencies = [
  "quote 1.0.7",
  "syn 1.0.33",
  "unicode-xid 0.2.1",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde-hex = "0.1.0"
 serde_json = "1.0"
 sha3 = "0.9"
+sled = "0.32"
 spectral = "0.6"
 structopt = "0.3"
 strum = "0.18"
@@ -46,6 +47,7 @@ version = "0.6"
 
 [dev-dependencies]
 proptest = "0.10"
+tempdir = "0.3"
 testcontainers = "0.9"
 
 [features]

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -372,7 +372,7 @@ mod tests {
         );
 
         let alice_swap = {
-            let swap_id = SwapId::random();
+            let swap_id = SwapId::default();
             let alice = WalletAlice {
                 alpha_wallet: alice_bitcoin_wallet.clone(),
                 beta_wallet: alice_ethereum_wallet.clone(),
@@ -398,7 +398,7 @@ mod tests {
         };
 
         let bob_swap = {
-            let swap_id = SwapId::random();
+            let swap_id = SwapId::default();
             let alice = WatchOnlyAlice {
                 alpha_connector: Arc::clone(&bitcoin_connector),
                 beta_connector: Arc::clone(&ethereum_connector),

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -164,6 +164,7 @@ where
 #[cfg(all(test, feature = "test-docker"))]
 mod tests {
     use super::*;
+    use crate::swap::db::Save;
     use crate::{
         bitcoin_wallet, ethereum_wallet,
         swap::{alice::wallet_actor::WalletAlice, bitcoin, bob::watch_only_actor::WatchOnlyBob},
@@ -232,33 +233,12 @@ mod tests {
     #[derive(Clone, Copy)]
     struct Database;
 
-    #[async_trait::async_trait]
-    impl<E> db::Load<E> for Database
-    where
-        E: 'static,
-    {
-        async fn load(&self, _swap_id: SwapId) -> anyhow::Result<Option<E>> {
-            Ok(None)
-        }
-    }
-
-    #[async_trait::async_trait]
-    impl<E> db::Save<E> for Database
-    where
-        E: Send + 'static,
-    {
-        async fn save(&self, _event: E, _swap_id: SwapId) -> anyhow::Result<()> {
-            Ok(())
-        }
-    }
-
     #[tokio::test]
     async fn execute_alice_hbit_herc20_swap() -> anyhow::Result<()> {
         let client = clients::Cli::default();
 
-        // let alice_db = db::Database::new_test().unwrap();
-        let alice_db = Database;
-        let bob_db = Database;
+        let alice_db = Arc::new(db::Database::new_test().unwrap());
+        let bob_db = Arc::new(db::Database::new_test().unwrap());
 
         let bitcoin_network = ::bitcoin::Network::Regtest;
         let (bitcoin_connector, bitcoind_url, bitcoin_blockchain) = {
@@ -374,10 +354,12 @@ mod tests {
 
         let alice_swap = {
             let swap_id = SwapId::default();
+            alice_db.save(db::Created, swap_id).await.unwrap();
+
             let alice = WalletAlice {
                 alpha_wallet: alice_bitcoin_wallet.clone(),
                 beta_wallet: alice_ethereum_wallet.clone(),
-                db: alice_db,
+                db: Arc::clone(&alice_db),
                 alpha_params: hbit::Params::new(hbit_params, hbit_transient_refund_sk),
                 beta_params: herc20_params.clone(),
                 secret,
@@ -400,10 +382,12 @@ mod tests {
 
         let bob_swap = {
             let swap_id = SwapId::default();
+            bob_db.save(db::Created, swap_id).await.unwrap();
+
             let alice = WatchOnlyAlice {
                 alpha_connector: Arc::clone(&bitcoin_connector),
                 beta_connector: Arc::clone(&ethereum_connector),
-                db: bob_db,
+                db: Arc::clone(&bob_db),
                 alpha_params: hbit_params,
                 beta_params: herc20_params.clone(),
                 secret_hash,

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -256,6 +256,7 @@ mod tests {
     async fn execute_alice_hbit_herc20_swap() -> anyhow::Result<()> {
         let client = clients::Cli::default();
 
+        // let alice_db = db::Database::new_test().unwrap();
         let alice_db = Database;
         let bob_db = Database;
 

--- a/src/swap/alice.rs
+++ b/src/swap/alice.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 pub struct WatchOnlyAlice<AC, BC, DB, AP, BP> {
     pub alpha_connector: Arc<AC>,
     pub beta_connector: Arc<BC>,
-    pub db: DB,
+    pub db: Arc<DB>,
     pub alpha_params: AP,
     pub beta_params: BP,
     pub secret_hash: SecretHash,
@@ -251,11 +251,11 @@ pub mod wallet_actor {
     use comit::Secret;
     use std::time::Duration;
 
-    #[derive(Clone, Copy, Debug)]
+    #[derive(Clone, Debug)]
     pub struct WalletAlice<AW, BW, DB, AP, BP> {
         pub alpha_wallet: AW,
         pub beta_wallet: BW,
-        pub db: DB,
+        pub db: Arc<DB>,
         pub alpha_params: AP,
         pub beta_params: BP,
         pub secret: Secret,

--- a/src/swap/bob.rs
+++ b/src/swap/bob.rs
@@ -11,12 +11,13 @@ use crate::{
 };
 use chrono::NaiveDateTime;
 use comit::{Secret, SecretHash, Timestamp};
+use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub struct WalletBob<AW, BW, DB, AP, BP> {
     pub alpha_wallet: AW,
     pub beta_wallet: BW,
-    pub db: DB,
+    pub db: Arc<DB>,
     pub alpha_params: AP,
     pub beta_params: BP,
     pub secret_hash: SecretHash,
@@ -225,7 +226,7 @@ pub mod watch_only_actor {
     pub struct WatchOnlyBob<AC, BC, DB, AP, BP> {
         pub alpha_connector: Arc<AC>,
         pub beta_connector: Arc<BC>,
-        pub db: DB,
+        pub db: Arc<DB>,
         pub alpha_params: AP,
         pub beta_params: BP,
         pub secret_hash: SecretHash,

--- a/src/swap/db.rs
+++ b/src/swap/db.rs
@@ -1,4 +1,7 @@
+use crate::swap::hbit;
 use crate::SwapId;
+use anyhow::{anyhow, Context};
+use serde::{Deserialize, Serialize};
 
 #[async_trait::async_trait]
 pub trait Load<T>: Send + Sync + 'static {
@@ -8,4 +11,152 @@ pub trait Load<T>: Send + Sync + 'static {
 #[async_trait::async_trait]
 pub trait Save<T>: Send + Sync + 'static {
     async fn save(&self, event: T, swap_id: SwapId) -> anyhow::Result<()>;
+}
+
+struct Database {
+    db: sled::Db,
+    #[cfg(test)]
+    tmp_dir: tempdir::TempDir,
+}
+
+impl Database {
+    #[cfg(not(test))]
+    pub fn new(path: &std::path::Path) -> anyhow::Result<Self> {
+        let path = path
+            .to_str()
+            .ok_or_else(|| anyhow!("The path is not utf-8 valid: {:?}", path))?;
+        let db = sled::open(path).context(format!("Could not open the DB at {}", path))?;
+        Ok(Database { db })
+    }
+
+    #[cfg(test)]
+    pub fn new_test() -> anyhow::Result<Self> {
+        let tmp_dir = tempdir::TempDir::new("nectar_test").unwrap();
+        let db = sled::open(tmp_dir.path()).context(format!(
+            "Could not open the DB at {}",
+            tmp_dir.path().display()
+        ))?;
+
+        Ok(Database { db, tmp_dir })
+    }
+
+    pub fn insert(&self, swap_id: &SwapId, swap: &Swap) -> anyhow::Result<()> {
+        let key = swap_id.as_bytes();
+        // TODO: Consider using https://github.com/3Hren/msgpack-rust instead
+        let value = serde_json::to_vec(&swap)
+            .context(format!("Could not serialize the swap: {:?}", swap))?;
+
+        self.db
+            .insert(&key, value)
+            .context(format!("Could not insert swap {}", swap_id))?;
+
+        Ok(())
+    }
+
+    pub fn get(&self, swap_id: &SwapId) -> anyhow::Result<Swap> {
+        let swap = self
+            .db
+            .get(swap_id.as_bytes())?
+            .ok_or_else(|| anyhow!("Swap does not exists {}", swap_id))?;
+
+        serde_json::from_slice(&swap).context("Could not deserialize swap")
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Swap {
+    pub hbit_funded: Option<HbitFunded>,
+}
+
+impl Default for Swap {
+    fn default() -> Self {
+        Swap { hbit_funded: None }
+    }
+}
+
+// TODO: control the serialisation
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct HbitFunded {
+    pub asset: u64,
+    pub location: ::bitcoin::OutPoint,
+}
+
+impl From<HbitFunded> for hbit::Funded {
+    fn from(funded: HbitFunded) -> Self {
+        hbit::Funded {
+            asset: comit::asset::Bitcoin::from_sat(funded.asset),
+            location: funded.location,
+        }
+    }
+}
+
+impl From<hbit::Funded> for HbitFunded {
+    fn from(funded: hbit::Funded) -> Self {
+        HbitFunded {
+            asset: funded.asset.as_sat(),
+            location: funded.location,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Save<hbit::Funded> for Database {
+    async fn save(&self, event: hbit::Funded, swap_id: SwapId) -> anyhow::Result<()> {
+        let stored_swap = self.get(&swap_id)?;
+
+        match stored_swap.hbit_funded {
+            Some(_) => Err(anyhow!("Hbit Funded event is already stored")),
+            None => {
+                let mut swap = stored_swap.clone();
+                swap.hbit_funded = Some(event.into());
+
+                let old_value = serde_json::to_vec(&stored_swap)
+                    .context("Could not serialize old swap value")?;
+                let new_value =
+                    serde_json::to_vec(&swap).context("Could not serialize new swap value")?;
+
+                self.db
+                    .compare_and_swap(swap_id.as_bytes(), Some(old_value), Some(new_value))
+                    .context("Could not write in the DB")?
+                    .context("Stored swap somehow changed, aborting saving")
+            }
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Load<hbit::Funded> for Database {
+    async fn load(&self, swap_id: SwapId) -> anyhow::Result<Option<hbit::Funded>> {
+        let swap = self.get(&swap_id)?;
+
+        Ok(swap.hbit_funded.map(Into::into))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn save_and_load_hbit_funded() {
+        let db = Database::new_test().unwrap();
+        let asset = comit::asset::Bitcoin::from_sat(123456);
+        let location = comit::htlc_location::Bitcoin::default();
+        let swap = Swap::default();
+        let swap_id = SwapId::default();
+
+        db.insert(&swap_id, &swap).unwrap();
+
+        let funded = hbit::Funded { asset, location };
+        db.save(funded, swap_id).await.unwrap();
+
+        let stored_funded = db
+            .load(swap_id)
+            .await
+            .expect("No error loading")
+            .expect("found the event");
+
+        assert_eq!(stored_funded.asset, asset);
+        assert_eq!(stored_funded.location, location);
+    }
 }

--- a/src/swap/do_action.rs
+++ b/src/swap/do_action.rs
@@ -229,7 +229,7 @@ mod tests {
 
         let db = FakeDatabase::default();
 
-        let swap_id = SwapId::random();
+        let swap_id = SwapId::default();
 
         let actor = FakeActor {
             db,
@@ -257,7 +257,7 @@ mod tests {
 
         let db = FakeDatabase::default();
 
-        let swap_id = SwapId::random();
+        let swap_id = SwapId::default();
 
         let actor = FakeActor {
             db,

--- a/src/swap_id.rs
+++ b/src/swap_id.rs
@@ -1,11 +1,24 @@
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use uuid::Uuid;
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct SwapId(Uuid);
 
 impl SwapId {
-    pub fn random() -> Self {
+    pub fn as_bytes(&self) -> &[u8; 16] {
+        self.0.as_bytes()
+    }
+}
+
+impl Default for SwapId {
+    fn default() -> Self {
         SwapId(Uuid::new_v4())
+    }
+}
+
+impl fmt::Display for SwapId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.to_string())
     }
 }


### PR DESCRIPTION
Ready to merge

I decided to go with `sled` crate. This is the most popular embedded crate I could find, it was also considered as part of the [DB spike](https://github.com/comit-network/spikes/blob/master/0009-comit-btsieve-db.adoc).

One of the downside for sled is that it is still `alpha`. It is now considered as `beta`. As it has not yet reached `1.0` we might want to have non-regression test on the binary format to ensure that we do not upgrade sled to a non backward compatible version and corrupt our db by mistake.


Please note that as this stage I only cater for events and cannnot load a `full` swap. Let's merge as is and do the `full swap save/load` in a new PR.

@luckysori can you point where you are using the `load full swap` feature to recover a swap so I know what API I need to provide?