### PR TITLE
Event loop optimisation and unreserving funds logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,6 +1939,7 @@ dependencies = [
  "ethabi",
  "ethereum-types",
  "futures",
+ "futures-timer",
  "hex 0.4.2",
  "libp2p",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ directories = "2.0"
 ethabi = "2.0.0"
 ethereum-types = "0.9.0"
 futures = "0.3.5"
+futures-timer = "3.0.2"
 hex = "0.4"
 libp2p = { version = "0.18", default-features = false, features = ["tcp", "secio", "yamux", "mplex", "mdns", "dns"] }
 log = "0.4"

--- a/proptest-regressions/order.txt
+++ b/proptest-regressions/order.txt
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 51b55d48ae9ca86628bcff631d23bb9d1a76624d065f74150a9de0779b0cd011 # shrinks to dai_balance = "60000000000000000000000000", dai_fees = "500000000", dai_reserved_funds = "0", dai_max_amount = "0", rate = 0.0, spread = 0
+cc 8cdaf059496e8b6c65d7c4878054acf7cb79d22f79446d6c526d8ac18c3a6e6f # shrinks to btc_balance = 0, btc_fees = 13264303946649277520, btc_reserved_funds = 5182440127060274096, btc_max_amount = 0, rate = 0.0, spread = 0
+cc ee10f77e9bd044c8e7a6f821e1af626db2647d8064d10d98ff0b7a94bfa4f3ab # shrinks to btc_balance = 12974373295788183248, btc_fees = 5472370777921368368, btc_reserved_funds = 12974373295788183248, btc_max_amount = 0, rate = 0.0, spread = 0

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -48,6 +48,14 @@ impl Amount {
 
         dai::Amount::from_atto(atto_dai)
     }
+
+    pub fn symbol(self) -> String {
+        "BTC".to_owned()
+    }
+
+    pub fn checked_add(self, rhs: Amount) -> Option<Amount> {
+        self.0.checked_add(rhs.0).map(Amount)
+    }
 }
 
 impl std::ops::Add for Amount {

--- a/src/dai.rs
+++ b/src/dai.rs
@@ -4,7 +4,7 @@ use crate::Rate;
 use comit::asset::Erc20;
 use comit::ethereum::{Address, ChainId};
 use conquer_once::Lazy;
-use num::{pow::Pow, BigUint, ToPrimitive, Zero};
+use num::{pow::Pow, BigUint, CheckedAdd, ToPrimitive, Zero};
 use std::str::FromStr;
 
 pub const ATTOS_IN_DAI_EXP: u16 = 18;
@@ -160,6 +160,14 @@ impl Amount {
             .ok_or_else(|| anyhow::anyhow!("Result is unexpectedly large"))?;
 
         Ok(bitcoin::Amount::from_sat(sats))
+    }
+
+    pub fn symbol(self) -> String {
+        "DAI".to_owned()
+    }
+
+    pub fn checked_add(self, rhs: Amount) -> Option<Amount> {
+        self.0.checked_add(&rhs.0).map(Amount)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,32 @@
 #![allow(unreachable_code, unused_variables, clippy::unit_arg)]
+#![recursion_limit = "256"]
 
 use anyhow::Context;
+use comit::{hbit, herc20};
+use futures::channel::mpsc::{Receiver, Sender};
+use futures::FutureExt;
+use futures::StreamExt;
+use futures::{Future, SinkExt};
+use futures_timer::Delay;
 use nectar::config::settings;
+use nectar::maker::Free;
 use nectar::maker::PublishOrders;
+use nectar::network::Taker;
+use nectar::order::Position;
 use nectar::{
-    bitcoin_wallet, config,
+    bitcoin, bitcoin_wallet, config,
     config::Settings,
-    ethereum_wallet,
+    dai, ethereum_wallet,
     maker::TakeRequestDecision,
     mid_market_rate::get_btc_dai_mid_market_rate,
     network::{self, Nectar, Orderbook},
     options::{self, Options},
-    Maker, Spread,
+    Maker, MidMarketRate, Spread,
 };
 use std::time::Duration;
 use structopt::StructOpt;
+
+const ENSURED_CONSUME_ZERO_BUFFER: usize = 0;
 
 async fn init_maker(
     bitcoin_wallet: bitcoin_wallet::Wallet,
@@ -46,6 +58,223 @@ async fn init_maker(
         ),
         // TODO better error handling
         _ => panic!("Maker initialisation failed!"),
+    }
+}
+
+fn init_rate_updates(
+    update_interval: Duration,
+) -> (
+    impl Future<Output = comit::Never> + Send,
+    Receiver<anyhow::Result<MidMarketRate>>,
+) {
+    let (mut sender, receiver) = futures::channel::mpsc::channel::<anyhow::Result<MidMarketRate>>(
+        ENSURED_CONSUME_ZERO_BUFFER,
+    );
+
+    let future = async move {
+        loop {
+            let rate = get_btc_dai_mid_market_rate().await;
+
+            if let Err(e) = sender.send(rate).await {
+                tracing::trace!("Error when sending rate update from sender to receiver.")
+            }
+
+            Delay::new(update_interval).await;
+        }
+    };
+
+    (future, receiver)
+}
+
+fn init_bitcoin_balance_updates(
+    update_interval: Duration,
+    wallet: bitcoin_wallet::Wallet,
+) -> (
+    impl Future<Output = comit::Never> + Send,
+    Receiver<anyhow::Result<bitcoin::Amount>>,
+) {
+    let (mut sender, receiver) = futures::channel::mpsc::channel::<anyhow::Result<bitcoin::Amount>>(
+        ENSURED_CONSUME_ZERO_BUFFER,
+    );
+
+    let future = async move {
+        loop {
+            let balance = wallet.balance().await;
+
+            if let Err(e) = sender.send(balance).await {
+                tracing::trace!("Error when sending balance update from sender to receiver.")
+            }
+
+            Delay::new(update_interval).await;
+        }
+    };
+
+    (future, receiver)
+}
+
+fn init_dai_balance_updates(
+    update_interval: Duration,
+    wallet: ethereum_wallet::Wallet,
+) -> (
+    impl Future<Output = comit::Never> + Send,
+    Receiver<anyhow::Result<dai::Amount>>,
+) {
+    let (mut sender, receiver) =
+        futures::channel::mpsc::channel::<anyhow::Result<dai::Amount>>(ENSURED_CONSUME_ZERO_BUFFER);
+
+    let future = async move {
+        loop {
+            let balance = wallet.dai_balance().await;
+
+            if let Err(e) = sender.send(balance.map(|balance| balance.into())).await {
+                tracing::trace!("Error when sending rate balance from sender to receiver.")
+            }
+
+            Delay::new(update_interval).await;
+        }
+    };
+
+    (future, receiver)
+}
+
+async fn execute_swap(sender: Sender<FinishedSwap>) -> anyhow::Result<()> {
+    let position: Position =
+        todo!("decision what kind of what swap it is hbit->herc20 or herc20->hbit");
+
+    let taker: Taker = todo!("Taker has to be available after execution, e.g. load from db");
+
+    match position {
+        Position::Sell => {
+            let beta_params: hbit::Params = unimplemented!();
+
+            // TODO: await hbit->herc20 swap execution
+
+            if let Err(e) = sender
+                .send(FinishedSwap::new(
+                    Free::Btc(beta_params.asset.into()),
+                    taker,
+                ))
+                .await
+            {
+                tracing::trace!("Error when sending execution finished from sender to receiver.")
+            }
+        }
+        Position::Buy => {
+            let beta_params: herc20::Params = unimplemented!();
+
+            // TODO: await herc20->hbit swap execution
+
+            if let Err(e) = sender
+                .send(FinishedSwap::new(
+                    Free::Dai(beta_params.asset.into()),
+                    taker,
+                ))
+                .await
+            {
+                tracing::trace!("Error when sending execution finished from sender to receiver.")
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_network_event(
+    network_event: network::Event,
+    maker: &mut Maker,
+    swarm: &mut libp2p::Swarm<Nectar>,
+    sender: Sender<FinishedSwap>,
+) {
+    match network_event {
+        network::Event::TakeRequest(order) => {
+            // decide & take & reserve
+            let result = maker.process_taken_order(order.clone());
+
+            match result {
+                Ok(TakeRequestDecision::GoForSwap) => {
+                    swarm.orderbook.take(order.clone());
+
+                    match maker.new_order(order.inner.position) {
+                        Ok(new_order) => {
+                            swarm.orderbook.publish(new_order.into());
+                        }
+                        Err(e) => tracing::error!("Error when trying to create new order: {}", e),
+                    }
+                }
+                Ok(TakeRequestDecision::RateNotProfitable)
+                | Ok(TakeRequestDecision::InsufficientFunds)
+                | Ok(TakeRequestDecision::CannotTradeWithTaker) => {
+                    swarm.orderbook.ignore(order);
+                }
+                Err(e) => {
+                    swarm.orderbook.ignore(order);
+                    tracing::error!("Processing taken order yielded error: {}", e)
+                }
+            }
+        }
+        network::Event::SwapFinalized(local_swap_id, remote_data) => {
+            tokio::spawn(execute_swap(sender));
+        }
+    }
+}
+
+fn handle_rate_update(
+    rate_update: anyhow::Result<MidMarketRate>,
+    maker: &mut Maker,
+    swarm: &mut libp2p::Swarm<Nectar>,
+) {
+    match rate_update {
+        Ok(new_rate) => {
+            let reaction = maker.update_rate(new_rate);
+            match reaction {
+                Ok(Some(PublishOrders {
+                    new_sell_order,
+                    new_buy_order,
+                })) => {
+                    swarm.orderbook.publish(new_sell_order.into());
+                    swarm.orderbook.publish(new_buy_order.into());
+                }
+                Ok(None) => (),
+                Err(e) => tracing::warn!("Rate update yielded error: {}", e),
+            }
+        }
+        Err(e) => {
+            maker.invalidate_rate();
+            tracing::error!(
+                "Unable to fetch latest rate! Fetching rate yielded error: {}",
+                e
+            );
+        }
+    }
+}
+
+fn handle_btc_balance_update(
+    btc_balance_update: anyhow::Result<bitcoin::Amount>,
+    maker: &mut Maker,
+    swarm: &mut libp2p::Swarm<Nectar>,
+) {
+    unimplemented!()
+}
+
+fn handle_dai_balance_update(
+    dai_balance_update: anyhow::Result<dai::Amount>,
+    maker: &mut Maker,
+    swarm: &mut libp2p::Swarm<Nectar>,
+) {
+    unimplemented!()
+}
+
+struct FinishedSwap {
+    funds_to_free: Free,
+    taker: Taker,
+}
+
+impl FinishedSwap {
+    pub fn new(funds_to_free: Free, taker: Taker) -> Self {
+        Self {
+            funds_to_free,
+            taker,
+        }
     }
 }
 
@@ -87,86 +316,41 @@ async fn main() {
         _ => panic!("Unable to publish initial orders!"),
     }
 
-    let network_event_timeout_secs: u64 = todo!("from config");
+    let update_interval = Duration::from_secs(15u64);
+
+    let (rate_future, rate_update_receiver) = init_rate_updates(update_interval);
+    let (btc_balance_future, btc_balance_update_receiver) =
+        init_bitcoin_balance_updates(update_interval, bitcoin_wallet);
+    let (dai_balance_future, dai_balance_update_receiver) =
+        init_dai_balance_updates(update_interval, ethereum_wallet);
+
+    tokio::spawn(rate_future);
+    tokio::spawn(btc_balance_future);
+    tokio::spawn(dai_balance_future);
+
+    let (swap_execution_finished_sender, swap_execution_finished_receiver) =
+        futures::channel::mpsc::channel::<FinishedSwap>(ENSURED_CONSUME_ZERO_BUFFER);
+
     loop {
-        let rate = get_btc_dai_mid_market_rate().await;
-        match rate {
-            Ok(new_rate) => {
-                let reaction = maker.update_rate(new_rate); // maker should record timestamp of this
-                match reaction {
-                    Ok(Some(PublishOrders {
-                        new_sell_order,
-                        new_buy_order,
-                    })) => {
-                        swarm.orderbook.publish(new_sell_order.into());
-                        swarm.orderbook.publish(new_buy_order.into());
-                    }
-                    Ok(None) => (),
-                    Err(e) => tracing::warn!("Rate update yielded error: {}", e),
+        futures::select! {
+            finished_swap = swap_execution_finished_receiver.next().fuse() => {
+                match finished_swap {
+                    Some(finished_swap) => maker.process_finished_swap(finished_swap.funds_to_free, finished_swap.taker),
+                    None => ()
                 }
+            },
+            network_event = swarm.next().fuse() => {
+                handle_network_event(network_event, &mut maker, &mut swarm, swap_execution_finished_sender.clone());
+            },
+            rate_update = rate_update_receiver.next().fuse() => {
+                handle_rate_update(rate_update.unwrap(), &mut maker, &mut swarm);
+            },
+            btc_balance_update = btc_balance_update_receiver.next().fuse() => {
+                handle_btc_balance_update(btc_balance_update.unwrap(), &mut maker, &mut swarm);
+            },
+            dai_balance_update = dai_balance_update_receiver.next().fuse() => {
+                handle_dai_balance_update(dai_balance_update.unwrap(), &mut maker, &mut swarm);
             }
-            Err(e) => {
-                maker.invalidate_rate();
-                tracing::error!(
-                    "Unable to fetch latest rate! Fetching rate yielded error: {}",
-                    e
-                );
-            }
-        }
-
-        let bitcoin_balance = bitcoin_wallet.balance().await;
-        match bitcoin_balance {
-            Ok(new_balance) => maker.update_bitcoin_balance(new_balance),
-            Err(e) => unimplemented!(),
-        }
-        let dai_balance = ethereum_wallet.dai_balance().await;
-        match dai_balance {
-            Ok(new_balance) => maker.update_dai_balance(new_balance.into()),
-            Err(e) => unimplemented!(),
-        }
-
-        // if nothing happens on the network for 15 seconds, loop
-        // again
-
-        // ASSUMPTION: a BtcDaiOrder Sell order and a BtcDaiOrder Buy
-        // order were published before we enter the loop (during
-        // initialization)
-        #[allow(clippy::single_match)]
-        match tokio::time::timeout(
-            Duration::from_secs(network_event_timeout_secs),
-            swarm.next(),
-        )
-        .await
-        {
-            Ok(event) => {
-                match event {
-                    network::Event::TakeRequest(order) => {
-                        // decide & take & reserve
-                        let result = maker.process_taken_order(order.clone());
-
-                        match result {
-                            Ok(TakeRequestDecision::GoForSwap { next_order }) => {
-                                swarm.orderbook.take(order);
-                                orderbook.publish(next_order.into());
-                            }
-                            Ok(TakeRequestDecision::RateNotProfitable)
-                            | Ok(TakeRequestDecision::InsufficientFunds)
-                            | Ok(TakeRequestDecision::CannotTradeWithTaker) => {
-                                swarm.orderbook.ignore(order);
-                            }
-                            Err(e) => {
-                                swarm.orderbook.ignore(order);
-                                tracing::error!("Processing taken order yielded error: {}", e)
-                            }
-                        }
-                    }
-                    network::Event::SwapFinalized(local_swap_id, remote_data) => {
-                        // TODO: Add remote_data learned from the other party to the swap and persist the swap
-                        // TODO: Spawn swap execution
-                    }
-                }
-            }
-            _ => (),
         }
     }
 }

--- a/src/ongoing_takers.rs
+++ b/src/ongoing_takers.rs
@@ -19,7 +19,7 @@ impl PeersWithOngoingTrades {
         self.0.contains(taker)
     }
 
-    fn remove(&mut self, taker: &Taker) {
+    pub fn remove(&mut self, taker: &Taker) {
         self.0.remove(taker);
     }
 }


### PR DESCRIPTION
Free funds and "remove taker from ongoing takers" logic.

This includes an update for the event loop model that allows us to process network events, swap execution events and balance/rate updates separately using `futures::select!`.

I would try to get this merged so that the new structure is in. Want to avoid rebasing this too often 😬