### PR TITLE
Merge bitcoin wallet `new` and `init` methods

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -294,6 +294,7 @@ async fn main() {
         settings.bitcoin.bitcoind.node_url,
         settings.bitcoin.network,
     )
+    .await
     .expect("can initialise bitcoin wallet");
     let ethereum_wallet = ethereum_wallet::Wallet::new(
         unimplemented!(),

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -279,8 +279,8 @@ mod tests {
             let seed = Seed::default();
             let bitcoin_wallet = {
                 let wallet =
-                    bitcoin_wallet::Wallet::new(seed, bitcoind_url.clone(), bitcoin_network)?;
-                wallet.init().await?;
+                    bitcoin_wallet::Wallet::new(seed, bitcoind_url.clone(), bitcoin_network)
+                        .await?;
 
                 bitcoin_blockchain
                     .mint(
@@ -308,13 +308,8 @@ mod tests {
 
         let (bob_bitcoin_wallet, bob_ethereum_wallet) = {
             let seed = Seed::default();
-            let bitcoin_wallet = {
-                let wallet =
-                    bitcoin_wallet::Wallet::new(seed, bitcoind_url.clone(), bitcoin_network)?;
-                wallet.init().await?;
-
-                wallet
-            };
+            let bitcoin_wallet =
+                bitcoin_wallet::Wallet::new(seed, bitcoind_url.clone(), bitcoin_network).await?;
             let ethereum_wallet =
                 ethereum_wallet::Wallet::new(seed, ethereum_node_url, token_contract)?;
 


### PR DESCRIPTION
We can see that the API was not used correctly in the main indicating
it is not the best API.

Initialisation of the wallet in bitcoind is now done when instantiating
the wallet.