### PR TITLE
Balance update logic

### DIFF
--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -49,10 +49,6 @@ impl Amount {
         dai::Amount::from_atto(atto_dai)
     }
 
-    pub fn symbol(self) -> String {
-        "BTC".to_owned()
-    }
-
     pub fn checked_add(self, rhs: Amount) -> Option<Amount> {
         self.0.checked_add(rhs.0).map(Amount)
     }

--- a/src/dai.rs
+++ b/src/dai.rs
@@ -162,10 +162,6 @@ impl Amount {
         Ok(bitcoin::Amount::from_sat(sats))
     }
 
-    pub fn symbol(self) -> String {
-        "DAI".to_owned()
-    }
-
     pub fn checked_add(self, rhs: Amount) -> Option<Amount> {
         self.0.checked_add(&rhs.0).map(Amount)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,10 +71,9 @@ pub fn data_dir() -> Option<std::path::PathBuf> {
 }
 
 #[derive(Debug, Copy, Clone, strum_macros::Display)]
+#[strum(serialize_all = "UPPERCASE")]
 pub enum Symbol {
-    #[strum(serialize = "BTC")]
     Btc,
-    #[strum(serialize = "DAI")]
     Dai,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,5 +70,27 @@ pub fn data_dir() -> Option<std::path::PathBuf> {
         .map(|proj_dirs| proj_dirs.data_dir().to_path_buf())
 }
 
+#[derive(Debug, Copy, Clone, strum_macros::Display)]
+pub enum Symbol {
+    #[strum(serialize = "BTC")]
+    Btc,
+    #[strum(serialize = "DAI")]
+    Dai,
+}
+
 #[cfg(all(test, feature = "test-docker"))]
 pub mod test_harness;
+
+#[cfg(test)]
+mod tests {
+    use crate::Symbol;
+
+    #[test]
+    fn symbol_serializes_correctly() {
+        let btc = Symbol::Btc;
+        let dai = Symbol::Dai;
+
+        assert_eq!(String::from("BTC"), btc.to_string());
+        assert_eq!(String::from("DAI"), dai.to_string());
+    }
+}

--- a/src/maker.rs
+++ b/src/maker.rs
@@ -6,7 +6,7 @@ use crate::{
     network::Order,
     order::{BtcDaiOrder, Position},
     rate::Spread,
-    MidMarketRate, PeersWithOngoingTrades, Rate,
+    MidMarketRate, PeersWithOngoingTrades, Rate, Symbol,
 };
 use std::convert::TryFrom;
 
@@ -18,8 +18,8 @@ pub enum NewOrder {
 // Bundles the state of the application
 #[derive(Debug)]
 pub struct Maker {
-    btc_balance: bitcoin::Amount,
-    dai_balance: dai::Amount,
+    btc_balance: Option<bitcoin::Amount>,
+    dai_balance: Option<dai::Amount>,
     btc_fee: bitcoin::Amount,
     pub btc_reserved_funds: bitcoin::Amount,
     pub dai_reserved_funds: dai::Amount,
@@ -42,8 +42,8 @@ impl Maker {
         spread: Spread,
     ) -> Self {
         Maker {
-            btc_balance,
-            dai_balance,
+            btc_balance: Some(btc_balance),
+            dai_balance: Some(dai_balance),
             btc_fee,
             btc_reserved_funds: Default::default(),
             dai_reserved_funds: Default::default(),
@@ -78,38 +78,72 @@ impl Maker {
         self.mid_market_rate = None;
     }
 
-    pub fn update_bitcoin_balance(&mut self, balance: bitcoin::Amount) {
-        self.btc_balance = balance;
+    pub fn update_bitcoin_balance(
+        &mut self,
+        balance: bitcoin::Amount,
+    ) -> anyhow::Result<Option<BtcDaiOrder>> {
+        // if we had a balance and the balance did not change => no new orders
+        if let Some(previous_balance) = self.btc_balance {
+            if previous_balance == balance {
+                return Ok(None);
+            }
+        }
+
+        self.btc_balance = Some(balance);
+        let order = self.new_sell_order()?;
+        Ok(Some(order))
     }
 
-    pub fn update_dai_balance(&mut self, balance: dai::Amount) {
-        self.dai_balance = balance;
+    pub fn invalidate_bitcoin_balance(&mut self) {
+        self.btc_balance = None;
+    }
+
+    pub fn update_dai_balance(
+        &mut self,
+        balance: dai::Amount,
+    ) -> anyhow::Result<Option<BtcDaiOrder>> {
+        // if we had a balance and the balance did not change => no new orders
+        if let Some(previous_balance) = self.dai_balance.clone() {
+            if previous_balance == balance {
+                return Ok(None);
+            }
+        }
+
+        self.dai_balance = Some(balance);
+        let order = self.new_buy_order()?;
+        Ok(Some(order))
+    }
+
+    pub fn invalidate_dai_balance(&mut self) {
+        self.dai_balance = None;
     }
 
     pub fn new_sell_order(&self) -> anyhow::Result<BtcDaiOrder> {
-        match self.mid_market_rate {
-            Some(mid_market_rate) => BtcDaiOrder::new_sell(
-                self.btc_balance,
+        match (self.mid_market_rate, self.btc_balance) {
+            (Some(mid_market_rate), Some(btc_balance)) => BtcDaiOrder::new_sell(
+                btc_balance,
                 self.btc_fee,
                 self.btc_reserved_funds,
                 self.btc_max_sell_amount,
                 mid_market_rate.into(),
                 self.spread,
             ),
-            None => anyhow::bail!(RateNotAvailable(Position::Sell)),
+            (None, _) => anyhow::bail!(RateNotAvailable(Position::Sell)),
+            (_, None) => anyhow::bail!(BalanceNotAvailable(Symbol::Btc)),
         }
     }
 
     pub fn new_buy_order(&self) -> anyhow::Result<BtcDaiOrder> {
-        match self.mid_market_rate {
-            Some(mid_market_rate) => BtcDaiOrder::new_buy(
-                self.dai_balance.clone(),
+        match (self.mid_market_rate, self.dai_balance.clone()) {
+            (Some(mid_market_rate), Some(dai_balance)) => BtcDaiOrder::new_buy(
+                dai_balance,
                 self.dai_reserved_funds.clone(),
                 self.dai_max_sell_amount.clone(),
                 mid_market_rate.into(),
                 self.spread,
             ),
-            None => anyhow::bail!(RateNotAvailable(Position::Buy)),
+            (None, _) => anyhow::bail!(RateNotAvailable(Position::Buy)),
+            (_, None) => anyhow::bail!(BalanceNotAvailable(Symbol::Dai)),
         }
     }
 
@@ -141,22 +175,27 @@ impl Maker {
                         position: Position::Buy,
                         ..
                     } => {
-                        // We are buying BTC for DAI
-                        // Given an order rate of: 1:9000
-                        // It is NOT profitable to buy, if the current rate is greater than the order rate.
-                        // 1:8800 -> We give less DAI for getting BTC -> Good.
-                        // 1:9200 -> We have to give more DAI for getting BTC -> Sucks.
-                        if order_rate > current_profitable_rate {
-                            return Ok(TakeRequestDecision::RateNotProfitable);
-                        }
+                        match self.dai_balance {
+                            Some(ref dai_balance) => {
+                                // We are buying BTC for DAI
+                                // Given an order rate of: 1:9000
+                                // It is NOT profitable to buy, if the current rate is greater than the order rate.
+                                // 1:8800 -> We give less DAI for getting BTC -> Good.
+                                // 1:9200 -> We have to give more DAI for getting BTC -> Sucks.
+                                if order_rate > current_profitable_rate {
+                                    return Ok(TakeRequestDecision::RateNotProfitable);
+                                }
 
-                        let updated_dai_reserved_funds =
-                            self.dai_reserved_funds.clone() + order.quote;
-                        if updated_dai_reserved_funds > self.dai_balance {
-                            return Ok(TakeRequestDecision::InsufficientFunds);
-                        }
+                                let updated_dai_reserved_funds =
+                                    self.dai_reserved_funds.clone() + order.quote;
+                                if updated_dai_reserved_funds > *dai_balance {
+                                    return Ok(TakeRequestDecision::InsufficientFunds);
+                                }
 
-                        self.dai_reserved_funds = updated_dai_reserved_funds;
+                                self.dai_reserved_funds = updated_dai_reserved_funds;
+                            }
+                            None => anyhow::bail!(BalanceNotAvailable(Symbol::Dai)),
+                        }
                     }
                     order
                     @
@@ -164,22 +203,27 @@ impl Maker {
                         position: Position::Sell,
                         ..
                     } => {
-                        // We are selling BTC for DAI
-                        // Given an order rate of: 1:9000
-                        // It is NOT profitable to sell, if the current rate is smaller than the order rate.
-                        // 1:8800 -> We get less DAI for our BTC -> Sucks.
-                        // 1:9200 -> We get more DAI for our BTC -> Good.
-                        if order_rate < current_profitable_rate {
-                            return Ok(TakeRequestDecision::RateNotProfitable);
-                        }
+                        match self.btc_balance {
+                            Some(btc_balance) => {
+                                // We are selling BTC for DAI
+                                // Given an order rate of: 1:9000
+                                // It is NOT profitable to sell, if the current rate is smaller than the order rate.
+                                // 1:8800 -> We get less DAI for our BTC -> Sucks.
+                                // 1:9200 -> We get more DAI for our BTC -> Good.
+                                if order_rate < current_profitable_rate {
+                                    return Ok(TakeRequestDecision::RateNotProfitable);
+                                }
 
-                        let updated_btc_reserved_funds =
-                            self.btc_reserved_funds + order.base + self.btc_fee;
-                        if updated_btc_reserved_funds > self.btc_balance {
-                            return Ok(TakeRequestDecision::InsufficientFunds);
-                        }
+                                let updated_btc_reserved_funds =
+                                    self.btc_reserved_funds + order.base + self.btc_fee;
+                                if updated_btc_reserved_funds > btc_balance {
+                                    return Ok(TakeRequestDecision::InsufficientFunds);
+                                }
 
-                        self.btc_reserved_funds = updated_btc_reserved_funds;
+                                self.btc_reserved_funds = updated_btc_reserved_funds;
+                            }
+                            None => anyhow::bail!(BalanceNotAvailable(Symbol::Btc)),
+                        }
                     }
                 };
 
@@ -231,6 +275,10 @@ pub struct PublishOrders {
 #[error("Rate not available when trying to create new {0} order.")]
 pub struct RateNotAvailable(Position);
 
+#[derive(Debug, Copy, Clone, thiserror::Error)]
+#[error("{0} balance not available.")]
+pub struct BalanceNotAvailable(Symbol);
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -245,8 +293,8 @@ mod tests {
     impl Default for Maker {
         fn default() -> Self {
             Self {
-                btc_balance: bitcoin::Amount::default(),
-                dai_balance: dai::Amount::default(),
+                btc_balance: Some(bitcoin::Amount::default()),
+                dai_balance: Some(dai::Amount::default()),
                 btc_fee: bitcoin::Amount::default(),
                 btc_reserved_funds: bitcoin::Amount::default(),
                 dai_reserved_funds: dai::Amount::default(),
@@ -259,10 +307,34 @@ mod tests {
         }
     }
 
+    fn btc(btc: f64) -> bitcoin::Amount {
+        bitcoin::Amount::from_btc(btc).unwrap()
+    }
+
+    fn dai(dai: f64) -> dai::Amount {
+        dai::Amount::from_dai_trunc(dai).unwrap()
+    }
+
+    fn some_btc(btc: f64) -> Option<bitcoin::Amount> {
+        Some(bitcoin::Amount::from_btc(btc).unwrap())
+    }
+
+    fn some_dai(dai: f64) -> Option<dai::Amount> {
+        Some(dai::Amount::from_dai_trunc(dai).unwrap())
+    }
+
+    fn some_rate(rate: f64) -> Option<MidMarketRate> {
+        Some(MidMarketRate::new(Rate::try_from(rate).unwrap()))
+    }
+
+    fn spread(spread: u16) -> Spread {
+        Spread::new(spread).unwrap()
+    }
+
     #[test]
     fn btc_funds_reserved_upon_taking_sell_order() {
         let mut maker = Maker {
-            btc_balance: bitcoin::Amount::from_btc(3.0).unwrap(),
+            btc_balance: some_btc(3.0),
             btc_fee: bitcoin::Amount::ZERO,
             ..Default::default()
         };
@@ -270,7 +342,7 @@ mod tests {
         let order_taken = Order {
             inner: BtcDaiOrder {
                 position: Position::Sell,
-                base: bitcoin::Amount::from_btc(1.5).unwrap(),
+                base: btc(1.5),
                 quote: dai::Amount::zero(),
             },
             ..Default::default()
@@ -279,24 +351,21 @@ mod tests {
         let event = maker.process_taken_order(order_taken).unwrap();
 
         assert_eq!(event, TakeRequestDecision::GoForSwap);
-        assert_eq!(
-            maker.btc_reserved_funds,
-            bitcoin::Amount::from_btc(1.5).unwrap()
-        )
+        assert_eq!(maker.btc_reserved_funds, btc(1.5))
     }
 
     #[test]
     fn btc_funds_reserved_upon_taking_sell_order_with_fee() {
         let mut maker = Maker {
-            btc_balance: bitcoin::Amount::from_btc(3.0).unwrap(),
-            btc_fee: bitcoin::Amount::from_btc(1.0).unwrap(),
+            btc_balance: some_btc(3.0),
+            btc_fee: btc(1.0),
             ..Default::default()
         };
 
         let order_taken = Order {
             inner: BtcDaiOrder {
                 position: Position::Sell,
-                base: bitcoin::Amount::from_btc(1.5).unwrap(),
+                base: btc(1.5),
                 quote: dai::Amount::zero(),
             },
             ..Default::default()
@@ -305,25 +374,22 @@ mod tests {
         let event = maker.process_taken_order(order_taken).unwrap();
 
         assert_eq!(event, TakeRequestDecision::GoForSwap);
-        assert_eq!(
-            maker.btc_reserved_funds,
-            bitcoin::Amount::from_btc(2.5).unwrap()
-        )
+        assert_eq!(maker.btc_reserved_funds, btc(2.5))
     }
 
     #[test]
     fn dai_funds_reserved_upon_taking_buy_order() {
         let mut maker = Maker {
-            dai_balance: dai::Amount::from_dai_trunc(10000.0).unwrap(),
-            mid_market_rate: Some(MidMarketRate::new(Rate::try_from(1.5).unwrap())),
+            dai_balance: some_dai(10000.0),
+            mid_market_rate: some_rate(1.5),
             ..Default::default()
         };
 
         let order_taken = Order {
             inner: BtcDaiOrder {
                 position: Position::Buy,
-                base: bitcoin::Amount::from_btc(1.0).unwrap(),
-                quote: dai::Amount::from_dai_trunc(1.5).unwrap(),
+                base: btc(1.0),
+                quote: dai(1.5),
             },
             ..Default::default()
         };
@@ -331,25 +397,22 @@ mod tests {
         let result = maker.process_taken_order(order_taken).unwrap();
 
         assert_eq!(result, TakeRequestDecision::GoForSwap);
-        assert_eq!(
-            maker.dai_reserved_funds,
-            dai::Amount::from_dai_trunc(1.5).unwrap()
-        )
+        assert_eq!(maker.dai_reserved_funds, dai(1.5))
     }
 
     #[test]
     fn dai_funds_reserved_upon_taking_buy_order_with_fee() {
         let mut maker = Maker {
-            dai_balance: dai::Amount::from_dai_trunc(10000.0).unwrap(),
-            mid_market_rate: Some(MidMarketRate::new(Rate::try_from(1.5).unwrap())),
+            dai_balance: some_dai(10000.0),
+            mid_market_rate: some_rate(1.5),
             ..Default::default()
         };
 
         let order_taken = Order {
             inner: BtcDaiOrder {
                 position: Position::Buy,
-                base: bitcoin::Amount::from_btc(1.0).unwrap(),
-                quote: dai::Amount::from_dai_trunc(1.5).unwrap(),
+                base: btc(1.0),
+                quote: dai(1.5),
             },
             ..Default::default()
         };
@@ -357,23 +420,20 @@ mod tests {
         let result = maker.process_taken_order(order_taken).unwrap();
 
         assert_eq!(result, TakeRequestDecision::GoForSwap);
-        assert_eq!(
-            maker.dai_reserved_funds,
-            dai::Amount::from_dai_trunc(1.5).unwrap()
-        )
+        assert_eq!(maker.dai_reserved_funds, dai(1.5))
     }
 
     #[test]
     fn not_enough_btc_funds_to_reserve_for_a_sell_order() {
         let mut maker = Maker {
-            btc_balance: bitcoin::Amount::ZERO,
+            btc_balance: Some(bitcoin::Amount::ZERO),
             ..Default::default()
         };
 
         let order_taken = Order {
             inner: BtcDaiOrder {
                 position: Position::Sell,
-                base: bitcoin::Amount::from_btc(1.5).unwrap(),
+                base: btc(1.5),
                 quote: dai::Amount::zero(),
             },
             ..Default::default()
@@ -387,16 +447,16 @@ mod tests {
     #[test]
     fn not_enough_btc_funds_to_reserve_for_a_buy_order() {
         let mut maker = Maker {
-            dai_balance: dai::Amount::zero(),
-            mid_market_rate: Some(MidMarketRate::new(Rate::try_from(1.5).unwrap())),
+            dai_balance: Some(dai::Amount::zero()),
+            mid_market_rate: some_rate(1.5),
             ..Default::default()
         };
 
         let order_taken = Order {
             inner: BtcDaiOrder {
                 position: Position::Buy,
-                base: bitcoin::Amount::from_btc(1.0).unwrap(),
-                quote: dai::Amount::from_dai_trunc(1.5).unwrap(),
+                base: btc(1.0),
+                quote: dai(1.5),
             },
             ..Default::default()
         };
@@ -409,15 +469,15 @@ mod tests {
     #[test]
     fn not_enough_btc_funds_to_reserve_for_a_sell_order_2() {
         let mut maker = Maker {
-            btc_balance: bitcoin::Amount::from_btc(2.0).unwrap(),
-            btc_reserved_funds: bitcoin::Amount::from_btc(1.5).unwrap(),
+            btc_balance: some_btc(2.0),
+            btc_reserved_funds: btc(1.5),
             ..Default::default()
         };
 
         let order_taken = Order {
             inner: BtcDaiOrder {
                 position: Position::Sell,
-                base: bitcoin::Amount::from_btc(1.0).unwrap(),
+                base: btc(1.0),
                 quote: dai::Amount::zero(),
             },
             ..Default::default()
@@ -431,7 +491,7 @@ mod tests {
     #[test]
     fn cannot_trade_with_taker_if_ongoing_swap_already_exists() {
         let mut maker = Maker {
-            btc_balance: bitcoin::Amount::from_btc(1.0).unwrap(),
+            btc_balance: some_btc(1.0),
             ..Default::default()
         };
 
@@ -445,7 +505,7 @@ mod tests {
 
         let result = maker.process_taken_order(order_taken.clone()).unwrap();
 
-        assert!(matches!(result, TakeRequestDecision::GoForSwap { .. }));
+        assert_eq!(result, TakeRequestDecision::GoForSwap);
 
         let result = maker.process_taken_order(order_taken).unwrap();
 
@@ -476,15 +536,15 @@ mod tests {
     #[test]
     fn fail_to_confirm_sell_order_if_sell_rate_is_not_good_enough() {
         let mut maker = Maker {
-            mid_market_rate: Some(MidMarketRate::new(Rate::try_from(10000.0).unwrap())),
+            mid_market_rate: some_rate(10000.0),
             ..Default::default()
         };
 
         let order_taken = Order {
             inner: BtcDaiOrder {
                 position: Position::Sell,
-                base: bitcoin::Amount::from_btc(1.0).unwrap(),
-                quote: dai::Amount::from_dai_trunc(9000.0).unwrap(),
+                base: btc(1.0),
+                quote: dai(9000.0),
             },
             ..Default::default()
         };
@@ -497,15 +557,15 @@ mod tests {
     #[test]
     fn fail_to_confirm_buy_order_if_buy_rate_is_not_good_enough() {
         let mut maker = Maker {
-            mid_market_rate: Some(MidMarketRate::new(Rate::try_from(10000.0).unwrap())),
+            mid_market_rate: some_rate(10000.0),
             ..Default::default()
         };
 
         let order_taken = Order {
             inner: BtcDaiOrder {
                 position: Position::Buy,
-                base: bitcoin::Amount::from_btc(1.0).unwrap(),
-                quote: dai::Amount::from_dai_trunc(11000.0).unwrap(),
+                base: btc(1.0),
+                quote: dai(11000.0),
             },
             ..Default::default()
         };
@@ -517,7 +577,7 @@ mod tests {
 
     #[test]
     fn no_rate_change_if_rate_update_with_same_value() {
-        let init_rate = Some(MidMarketRate::new(Rate::try_from(1.0).unwrap()));
+        let init_rate = some_rate(1.0);
         let mut maker = Maker {
             mid_market_rate: init_rate,
             ..Default::default()
@@ -525,33 +585,33 @@ mod tests {
 
         let new_mid_market_rate = MidMarketRate::new(Rate::try_from(1.0).unwrap());
 
-        let reaction = maker.update_rate(new_mid_market_rate).unwrap();
-        assert!(reaction.is_none());
+        let result = maker.update_rate(new_mid_market_rate).unwrap();
+        assert!(result.is_none());
         assert_eq!(maker.mid_market_rate, init_rate)
     }
 
     #[test]
     fn rate_updated_and_new_orders_if_rate_update_with_new_value() {
         let mut maker = Maker {
-            btc_balance: bitcoin::Amount::from_btc(10.0).unwrap(),
-            dai_balance: dai::Amount::from_dai_trunc(10.0).unwrap(),
-            mid_market_rate: Some(MidMarketRate::new(Rate::try_from(1.0).unwrap())),
+            btc_balance: some_btc(10.0),
+            dai_balance: some_dai(10.0),
+            mid_market_rate: some_rate(1.0),
             ..Default::default()
         };
 
         let new_mid_market_rate = MidMarketRate::new(Rate::try_from(2.0).unwrap());
 
-        let reaction = maker.update_rate(new_mid_market_rate).unwrap();
-        assert!(reaction.is_some());
+        let result = maker.update_rate(new_mid_market_rate).unwrap();
+        assert!(result.is_some());
         assert_eq!(maker.mid_market_rate, Some(new_mid_market_rate))
     }
 
     #[test]
     fn free_funds_and_remove_ongoing_taker_when_processing_finished_swap() {
         let mut maker = Maker {
-            btc_reserved_funds: bitcoin::Amount::from_btc(1.1).unwrap(),
-            dai_reserved_funds: dai::Amount::from_dai_trunc(1.0).unwrap(),
-            btc_fee: bitcoin::Amount::from_btc(0.1).unwrap(),
+            btc_reserved_funds: btc(1.1),
+            dai_reserved_funds: dai(1.0),
+            btc_fee: btc(0.1),
             ..Default::default()
         };
 
@@ -559,20 +619,121 @@ mod tests {
 
         maker.ongoing_takers.insert(taker).unwrap();
 
-        let free_btc = Free::Btc(bitcoin::Amount::from_btc(0.5).unwrap());
-        let free_dai = Free::Dai(dai::Amount::from_dai_trunc(0.5).unwrap());
+        let free_btc = Free::Btc(btc(0.5));
+        let free_dai = Free::Dai(dai(0.5));
 
         maker.process_finished_swap(free_btc, taker);
-        assert_eq!(
-            maker.btc_reserved_funds,
-            bitcoin::Amount::from_btc(0.5).unwrap()
-        );
+        assert_eq!(maker.btc_reserved_funds, btc(0.5));
 
         maker.process_finished_swap(free_dai, taker);
-        assert_eq!(
-            maker.dai_reserved_funds,
-            dai::Amount::from_dai_trunc(0.5).unwrap()
-        );
+        assert_eq!(maker.dai_reserved_funds, dai(0.5));
         assert!(!maker.ongoing_takers.has_an_ongoing_trade(&taker));
+    }
+
+    #[test]
+    fn no_new_sell_order_if_no_btc_balance_change() {
+        let mut maker = Maker {
+            btc_balance: some_btc(1.0),
+            ..Default::default()
+        };
+
+        let result = maker.update_bitcoin_balance(btc(1.0)).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn no_new_buy_order_if_no_dai_balance_change() {
+        let mut maker = Maker {
+            dai_balance: some_dai(1.0),
+            ..Default::default()
+        };
+
+        let result = maker.update_dai_balance(dai(1.0)).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn new_sell_order_if_btc_balance_change() {
+        let mut maker = Maker {
+            btc_balance: some_btc(1.0),
+            btc_max_sell_amount: None,
+            btc_fee: bitcoin::Amount::ZERO,
+            mid_market_rate: some_rate(1.0),
+            spread: spread(0),
+            ..Default::default()
+        };
+        let new_balance = btc(0.5);
+
+        let new_sell_order = maker.update_bitcoin_balance(new_balance).unwrap().unwrap();
+        assert_eq!(new_sell_order.position, Position::Sell);
+        assert_eq!(maker.btc_balance, Some(new_balance))
+    }
+
+    #[test]
+    fn new_buy_order_if_dai_balance_change() {
+        let mut maker = Maker {
+            dai_balance: some_dai(1.0),
+            dai_max_sell_amount: None,
+            mid_market_rate: some_rate(1.0),
+            spread: spread(0),
+            ..Default::default()
+        };
+        let new_balance = dai(0.5);
+
+        let new_buy_order = maker
+            .update_dai_balance(new_balance.clone())
+            .unwrap()
+            .unwrap();
+        assert_eq!(new_buy_order.position, Position::Buy);
+        assert_eq!(maker.dai_balance, Some(new_balance))
+    }
+
+    #[test]
+    fn published_sell_order_can_be_taken() {
+        let mut maker = Maker {
+            btc_balance: some_btc(3.0),
+            btc_fee: bitcoin::Amount::ZERO,
+            btc_max_sell_amount: some_btc(1.0),
+            mid_market_rate: some_rate(1.0),
+            ..Default::default()
+        };
+
+        let new_sell_order = maker.new_sell_order().unwrap();
+        assert_eq!(new_sell_order.base, btc(1.0));
+
+        let taker = Taker::default();
+        let result = maker
+            .process_taken_order(Order {
+                inner: new_sell_order,
+                taker,
+            })
+            .unwrap();
+
+        assert_eq!(result, TakeRequestDecision::GoForSwap);
+        assert_eq!(maker.btc_reserved_funds, btc(1.0))
+    }
+
+    #[test]
+    fn published_buy_order_can_be_taken() {
+        let mut maker = Maker {
+            dai_balance: some_dai(3.0),
+            dai_max_sell_amount: some_dai(1.0),
+            mid_market_rate: some_rate(1.0),
+            ..Default::default()
+        };
+
+        let new_buy_order = maker.new_buy_order().unwrap();
+        assert_eq!(new_buy_order.quote, dai(1.0));
+
+        let taker = Taker::default();
+        let result = maker
+            .process_taken_order(Order {
+                inner: new_buy_order,
+                taker,
+            })
+            .unwrap();
+
+        assert_eq!(result, TakeRequestDecision::GoForSwap);
+        assert_eq!(maker.dai_reserved_funds, dai(1.0))
     }
 }

--- a/src/order.rs
+++ b/src/order.rs
@@ -1,7 +1,8 @@
-use crate::dai;
 use crate::{bitcoin, Symbol};
+use crate::{dai, MidMarketRate};
 use crate::{Rate, Spread};
 use std::cmp::min;
+use std::convert::TryFrom;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum_macros::Display)]
 pub enum Position {
@@ -79,6 +80,28 @@ impl BtcDaiOrder {
             base,
             quote,
         })
+    }
+
+    pub fn is_as_good_as(&self, mid_market_rate: MidMarketRate) -> anyhow::Result<bool> {
+        let order_rate = Rate::try_from(self.clone())?;
+        match self.position {
+            Position::Buy => {
+                // We are buying BTC for DAI
+                // Given an order rate of: 1:9000
+                // It is NOT profitable to buy, if the current rate is greater than the order rate.
+                // 1:8800 -> We give less DAI for getting BTC -> Good.
+                // 1:9200 -> We have to give more DAI for getting BTC -> Sucks.
+                Ok(order_rate <= mid_market_rate.into())
+            }
+            Position::Sell => {
+                // We are selling BTC for DAI
+                // Given an order rate of: 1:9000
+                // It is NOT profitable to sell, if the current rate is smaller than the order rate.
+                // 1:8800 -> We get less DAI for our BTC -> Sucks.
+                // 1:9200 -> We get more DAI for our BTC -> Good.
+                Ok(order_rate >= mid_market_rate.into())
+            }
+        }
     }
 }
 
@@ -301,6 +324,90 @@ mod tests {
 
         let result = BtcDaiOrder::new_buy(dai(1.0), dai(2.0), None, rate, spread);
         assert!(result.unwrap_err().downcast::<InsufficientFunds>().is_ok());
+    }
+
+    #[test]
+    fn sell_order_is_as_good_as_market_rate() {
+        let order = BtcDaiOrder {
+            position: Position::Sell,
+            base: btc(1.0),
+            quote: dai(1.0),
+        };
+
+        let rate = MidMarketRate::new(Rate::try_from(1.0).unwrap());
+
+        let is_profitable = order.is_as_good_as(rate).unwrap();
+        assert!(is_profitable)
+    }
+
+    #[test]
+    fn sell_order_is_better_than_market_rate() {
+        let order = BtcDaiOrder {
+            position: Position::Sell,
+            base: btc(1.0),
+            quote: dai(1.0),
+        };
+
+        let rate = MidMarketRate::new(Rate::try_from(0.9).unwrap());
+
+        let is_profitable = order.is_as_good_as(rate).unwrap();
+        assert!(is_profitable)
+    }
+
+    #[test]
+    fn sell_order_is_worse_than_market_rate() {
+        let order = BtcDaiOrder {
+            position: Position::Sell,
+            base: btc(1.0),
+            quote: dai(1.0),
+        };
+
+        let rate = MidMarketRate::new(Rate::try_from(1.1).unwrap());
+
+        let is_profitable = order.is_as_good_as(rate).unwrap();
+        assert!(!is_profitable)
+    }
+
+    #[test]
+    fn buy_order_is_as_good_as_market_rate() {
+        let order = BtcDaiOrder {
+            position: Position::Buy,
+            base: btc(1.0),
+            quote: dai(1.0),
+        };
+
+        let rate = MidMarketRate::new(Rate::try_from(1.0).unwrap());
+
+        let is_profitable = order.is_as_good_as(rate).unwrap();
+        assert!(is_profitable)
+    }
+
+    #[test]
+    fn buy_order_is_better_than_market_rate() {
+        let order = BtcDaiOrder {
+            position: Position::Buy,
+            base: btc(1.0),
+            quote: dai(1.0),
+        };
+
+        let rate = MidMarketRate::new(Rate::try_from(1.1).unwrap());
+
+        let is_profitable = order.is_as_good_as(rate).unwrap();
+        assert!(is_profitable)
+    }
+
+    #[test]
+    fn buy_order_is_worse_than_market_rate() {
+        let order = BtcDaiOrder {
+            position: Position::Buy,
+            base: btc(1.0),
+            quote: dai(1.0),
+        };
+
+        let rate = MidMarketRate::new(Rate::try_from(0.9).unwrap());
+
+        let is_profitable = order.is_as_good_as(rate).unwrap();
+        assert!(!is_profitable)
     }
 
     proptest! {

--- a/src/order.rs
+++ b/src/order.rs
@@ -1,5 +1,5 @@
-use crate::bitcoin;
 use crate::dai;
+use crate::{bitcoin, Symbol};
 use crate::{Rate, Spread};
 use std::cmp::min;
 
@@ -34,7 +34,7 @@ impl BtcDaiOrder {
         match base_reserved_funds.checked_add(base_fees) {
             Some(added) => {
                 if base_balance <= added {
-                    anyhow::bail!(InsufficientFunds(base_balance.symbol()))
+                    anyhow::bail!(InsufficientFunds(Symbol::Btc))
                 }
             }
             None => anyhow::bail!(Overflow),
@@ -63,7 +63,7 @@ impl BtcDaiOrder {
         spread: Spread,
     ) -> anyhow::Result<BtcDaiOrder> {
         if quote_balance <= quote_reserved_funds {
-            anyhow::bail!(InsufficientFunds(quote_balance.symbol()))
+            anyhow::bail!(InsufficientFunds(Symbol::Dai))
         }
 
         let quote = match max_amount {
@@ -82,9 +82,9 @@ impl BtcDaiOrder {
     }
 }
 
-#[derive(Debug, Clone, thiserror::Error)]
+#[derive(Debug, Copy, Clone, thiserror::Error)]
 #[error("Insufficient {0} funds to create new order.")]
-pub struct InsufficientFunds(String);
+pub struct InsufficientFunds(Symbol);
 
 #[derive(Debug, Copy, Clone, thiserror::Error)]
 #[error("The maximum amount for an order cannot be smaller than the maximum fee.")]


### PR DESCRIPTION
First Commit: More complex logic, that takes the max-amount into account.
After sleeping over this on the weekend I feel it is unnecessarily complex at the moment.
I think it is totally fine to publish orders upon every balance change, even if that means "spamming" the network if the order's amounts did not change. 