### PR TITLE
Depend on definitely stable version of COMIT lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "comit"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/comit-rs?branch=nectar#fb1698e59677f9f67e60cd3c208ebf5ee702e546"
+source = "git+https://github.com/comit-network/comit-rs?branch=nectar#fef90c6f48deb633e96f600ada6673cc2e6b8cf4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -761,7 +761,7 @@ dependencies = [
 [[package]]
 name = "digest"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/comit-rs?branch=nectar#fb1698e59677f9f67e60cd3c208ebf5ee702e546"
+source = "git+https://github.com/comit-network/comit-rs?branch=nectar#fef90c6f48deb633e96f600ada6673cc2e6b8cf4"
 dependencies = [
  "digest-macro-derive",
  "hex 0.4.2",
@@ -788,7 +788,7 @@ dependencies = [
 [[package]]
 name = "digest-macro-derive"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/comit-rs?branch=nectar#fb1698e59677f9f67e60cd3c208ebf5ee702e546"
+source = "git+https://github.com/comit-network/comit-rs?branch=nectar#fef90c6f48deb633e96f600ada6673cc2e6b8cf4"
 dependencies = [
  "hex 0.4.2",
  "proc-macro2 1.0.18",


### PR DESCRIPTION
To prevent breaking this dependency in the future:

- No more force pushing to `comit-rs/nectar`.
- Use path dependency or a separate branch if you need to make changes to `comit-rs/nectar`.
- Once the corresponding Nectar PR is approved, update `comit-rs/nectar` with the changes, run `cargo update -p comit` to update the dependency on the PR branch and go ahead with merging the PR.