### PR TITLE
Generate the Bitcoin root extended private key from the seed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 anyhow = "1"
 async-trait = "0.1"
 bimap = "0.4"
-bitcoin = { version = "0.23.0", features = ["rand", "serde"] }
+bitcoin = { version = "0.23.0", features = ["rand", "use-serde"] }
 chrono = "0.4"
 clarity = "0.1"
 comit = { git = "https://github.com/comit-network/comit-rs", package = "comit", branch = "nectar" }

--- a/src/bitcoin/wallet.rs
+++ b/src/bitcoin/wallet.rs
@@ -215,6 +215,7 @@ impl Wallet {
         Ok(())
     }
 
+    // TODO: Just hash the seed instead of the public key of the seed (as a private key)
     fn gen_name(private_key: PrivateKey) -> String {
         let mut hash_engine = PubkeyHash::engine();
         private_key

--- a/src/bitcoin/wallet.rs
+++ b/src/bitcoin/wallet.rs
@@ -1,13 +1,19 @@
-use crate::{
-    bitcoin::{Address, Amount, Client, Network, WalletInfoResponse},
-    seed::Seed,
+use crate::bitcoin::{Address, Amount, Client, Network, WalletInfoResponse};
+use crate::seed::Seed;
+use ::bitcoin::{
+    hash_types::PubkeyHash,
+    hashes::Hash,
+    hashes::{sha512, HashEngine, Hmac, HmacEngine},
+    secp256k1,
+    secp256k1::SecretKey,
+    util::bip32::ExtendedPrivKey,
+    PrivateKey, Transaction, Txid,
 };
 use anyhow::Context;
-use bitcoin::{
-    hash_types::PubkeyHash, hashes::Hash, secp256k1::SecretKey, PrivateKey, Transaction, Txid,
-};
+use bitcoin::util::bip32::ChainCode;
 use rand::RngCore;
 use sha2::{Digest, Sha256};
+use std::path::Path;
 use url::Url;
 
 #[derive(Debug, Clone)]
@@ -15,13 +21,13 @@ pub struct Wallet {
     /// The wallet is named `nectar_x` with `x` being the first 4 byte of the public key hash
     name: String,
     bitcoind_client: Client,
-    private_key: bitcoin::PrivateKey,
+    seed: Seed,
     network: Network,
 }
 
 impl Wallet {
     pub async fn new(seed: Seed, url: Url, network: Network) -> anyhow::Result<Wallet> {
-        let key = seed.secret_key()?;
+        let key = secp256k1::SecretKey::from_slice(&seed.bytes())?;
 
         let private_key = ::bitcoin::PrivateKey {
             compressed: true,
@@ -36,7 +42,7 @@ impl Wallet {
         let wallet = Wallet {
             name,
             bitcoind_client,
-            private_key,
+            seed,
             network,
         };
 
@@ -56,7 +62,7 @@ impl Wallet {
                 .create_wallet(&self.name, None, Some(true), None, None)
                 .await?;
 
-            let wif = self.wif();
+            let wif = self.seed_as_wif();
 
             self.bitcoind_client
                 .set_hd_seed(&self.name, Some(true), Some(wif))
@@ -71,7 +77,7 @@ impl Wallet {
         let mut random_bytes = [0u8; 32];
 
         rand::thread_rng().fill_bytes(&mut random_bytes);
-
+        // TODO: use bitcoin_hashes instead of adding new dependency sha2
         let mut hash = Sha256::new();
         hash.update(random_bytes);
 
@@ -102,12 +108,57 @@ impl Wallet {
             .await
     }
 
-    /// Returns the private key in wif format, this allows the user to import the wallet in a
+    /// Returns the seed in wif format, this allows the user to import the wallet in a
     /// different bitcoind using `sethdseed`.
     /// It seems relevant that access to bitcoind must not be needed to complete the task
     /// in case there is an issue with bitcoind and the user wants to regain control over their wallet
-    pub fn wif(&self) -> String {
-        self.private_key.to_wif()
+    /// Do note that the `wif` format is only here to allow the communication of `bytes`. The seed
+    /// is NOT used as a private key in bitcoin. See `root_extended_private_key` to get the
+    /// root private key of the bip32 hd wallet.
+    // TODO: check the network against bitcoind in a non-failing manner (just log)
+    pub fn seed_as_wif(&self) -> String {
+        let key = self.seed.as_secret_key();
+
+        let private_key = PrivateKey {
+            compressed: true,
+            network: self.network,
+            key,
+        };
+
+        private_key.to_wif()
+    }
+
+    /// This seems to be the standard way to get a root extended private key from a seed
+    /// This is the way bitcoind does it when being passed a seed with `sethdseed`
+    // TODO: check the network against bitcoind in a non-failing manner (just log)
+    pub fn root_extended_private_key(&self) -> ExtendedPrivKey {
+        let bytes = self.seed.bytes();
+        let hash_key = b"Bitcoin seed";
+
+        let mut engine = HmacEngine::<sha512::Hash>::new(hash_key);
+        engine.input(&bytes);
+        let hash = Hmac::<sha512::Hash>::from_engine(engine);
+        let output = &hash.into_inner()[..];
+        let key = &output[..32];
+        let chain_code = &output[32..];
+
+        let key = SecretKey::from_slice(key).expect("32 bytes array should be fine");
+        let private_key = PrivateKey {
+            compressed: true,
+            network: self.network,
+            key,
+        };
+
+        let chain_code = ChainCode::from(chain_code);
+
+        ExtendedPrivKey {
+            network: self.network,
+            depth: 0,
+            parent_fingerprint: Default::default(),
+            child_number: 0.into(),
+            private_key,
+            chain_code,
+        }
     }
 
     pub async fn send_to_address(
@@ -150,6 +201,10 @@ impl Wallet {
         Ok(transaction)
     }
 
+    pub async fn dump(&self, filename: &Path) -> anyhow::Result<()> {
+        self.bitcoind_client.dump_wallet(&self.name, filename).await
+    }
+
     async fn assert_network(&self, expected: Network) -> anyhow::Result<()> {
         let actual = self.bitcoind_client.network().await?;
 
@@ -178,6 +233,10 @@ impl Wallet {
 mod docker_tests {
     use super::*;
     use crate::test_harness::bitcoin;
+    use std::fs::File;
+    use std::io::{BufRead, BufReader};
+    use std::process::{Command, Stdio};
+    use tempdir::TempDir;
     use testcontainers::clients;
 
     #[tokio::test]
@@ -187,12 +246,68 @@ mod docker_tests {
 
         blockchain.init().await.unwrap();
 
-        let seed = Seed::default();
+        let seed = Seed::random().unwrap();
         let wallet = Wallet::new(seed, blockchain.node_url.clone(), Network::Regtest)
             .await
             .unwrap();
 
         let _address = wallet.new_address().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn root_key_calculated_from_seed_is_the_same_than_bitcoind_s() {
+        let tc_client = clients::Cli::default();
+        let blockchain = bitcoin::Blockchain::new(&tc_client).unwrap();
+
+        blockchain.init().await.unwrap();
+
+        let seed = Seed::random().unwrap();
+        let wallet = Wallet::new(seed, blockchain.node_url.clone(), Network::Regtest)
+            .await
+            .unwrap();
+
+        let wif_path_docker = Path::new("/wallet.wif");
+
+        let _ = wallet.dump(wif_path_docker).await.unwrap();
+
+        // Wait for bitcoind to write the wif file
+        std::thread::sleep(std::time::Duration::from_secs(3600));
+
+        let tmp_dir = TempDir::new("nectar_test").unwrap();
+        let path = tmp_dir.path().join("wallet.wif");
+
+        Command::new("docker")
+            .arg("cp")
+            .arg(format!(
+                "{}:{}",
+                blockchain.container_id(),
+                wif_path_docker.display()
+            ))
+            .arg(path.clone())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("Failed to execute docker cp")
+            .wait()
+            .expect("Failed to run docker cp");
+
+        let wif = File::open(path).unwrap();
+        let wif = BufReader::new(wif);
+
+        // The line we are looking for looks like that:
+        // # extended private masterkey: tprv...
+
+        let line = wif
+            .lines()
+            .find(|line| {
+                line.as_ref()
+                    .map(|line| line.starts_with("# extended private masterkey: "))
+                    .unwrap_or(false)
+            })
+            .unwrap()
+            .unwrap();
+
+        let key = line.split_ascii_whitespace().last().unwrap();
+        assert_eq!(key, &wallet.root_extended_private_key().to_string());
     }
 
     #[tokio::test]
@@ -202,7 +317,7 @@ mod docker_tests {
 
         blockchain.init().await.unwrap();
 
-        let seed = Seed::default();
+        let seed = Seed::random().unwrap();
         let wallet = Wallet::new(seed, blockchain.node_url.clone(), Network::Regtest)
             .await
             .unwrap();
@@ -217,7 +332,7 @@ mod docker_tests {
 
         blockchain.init().await.unwrap();
 
-        let seed = Seed::default();
+        let seed = Seed::random().unwrap();
         {
             let wallet = Wallet::new(seed, blockchain.node_url.clone(), Network::Regtest)
                 .await

--- a/src/ethereum/wallet.rs
+++ b/src/ethereum/wallet.rs
@@ -21,7 +21,7 @@ impl Wallet {
         url: Url,
         dai_contract_addr: comit::ethereum::Address,
     ) -> anyhow::Result<Self> {
-        let private_key = clarity::PrivateKey::from_slice(&seed.secret_key_bytes())
+        let private_key = clarity::PrivateKey::from_slice(&seed.bytes())
             .map_err(|_| anyhow::anyhow!("Failed to derive private key from slice"))?;
 
         let geth_client = Client::new(url);
@@ -52,6 +52,10 @@ impl Wallet {
         bytes.copy_from_slice(pk.as_bytes());
 
         Address::from(bytes)
+    }
+
+    pub fn private_key(&self) -> clarity::PrivateKey {
+        self.private_key
     }
 
     pub async fn deploy_contract(

--- a/src/network.rs
+++ b/src/network.rs
@@ -536,7 +536,7 @@ impl From<PublishOrder> for comit::network::orderbook::NewOrder {
 
 fn derive_key_pair(seed: &Seed) -> libp2p::identity::Keypair {
     let mut sha = Sha256::new();
-    sha.update(seed.seed_bytes());
+    sha.update(seed.bytes());
     sha.update(b"LIBP2P_KEYPAIR");
 
     let bytes = sha.finalize();

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -393,7 +393,7 @@ mod tests {
         };
 
         let (alice_bitcoin_wallet, alice_ethereum_wallet) = {
-            let seed = Seed::default();
+            let seed = Seed::random().unwrap();
             let bitcoin_wallet = {
                 let wallet =
                     crate::bitcoin::Wallet::new(seed, bitcoind_url.clone(), bitcoin_network)
@@ -424,7 +424,7 @@ mod tests {
         };
 
         let (bob_bitcoin_wallet, bob_ethereum_wallet) = {
-            let seed = Seed::default();
+            let seed = Seed::random().unwrap();
             let bitcoin_wallet =
                 crate::bitcoin::Wallet::new(seed, bitcoind_url.clone(), bitcoin_network).await?;
             let ethereum_wallet =

--- a/src/test_harness/bitcoin.rs
+++ b/src/test_harness/bitcoin.rs
@@ -65,6 +65,10 @@ impl<'c> Blockchain<'c> {
 
         Ok(())
     }
+
+    pub fn container_id(&self) -> &str {
+        self._container.id()
+    }
 }
 
 async fn mine(


### PR DESCRIPTION
This is done the same manner than bitcoind does. Which means
that the seed can later be imported directly in bitcoind for
recovery purposes.

A test is done to prove it.