### PR TITLE
Reserve funds before respawn

### DIFF
--- a/src/command/trade.rs
+++ b/src/command/trade.rs
@@ -392,17 +392,10 @@ fn handle_network_event(
                     }
                 }
                 Ok(TakeRequestDecision::RateNotProfitable)
-                | Ok(TakeRequestDecision::InsufficientFunds)
-                | Ok(TakeRequestDecision::CannotTradeWithTaker) => {
-                    let _ = swarm
-                        .deny(order)
-                        .map_err(|e| tracing::error!("Failed to deny order: {}", e));
-                }
+                | Ok(TakeRequestDecision::InsufficientFunds) => swarm.deny(order),
                 Err(e) => {
-                    let _ = swarm
-                        .deny(order)
-                        .map_err(|e| tracing::error!("Failed to deny order: {}", e));
-                    tracing::error!("Processing taken order yielded error: {}", e)
+                    tracing::error!("Processing taken order yielded error: {}", e);
+                    swarm.deny(order)
                 }
             }
         }

--- a/src/maker.rs
+++ b/src/maker.rs
@@ -26,7 +26,7 @@ pub struct TakenOrder {
 pub struct Maker {
     btc_balance: Option<bitcoin::Amount>,
     dai_balance: Option<dai::Amount>,
-    btc_fee: bitcoin::Amount,
+    pub btc_fee: bitcoin::Amount,
     pub btc_reserved_funds: bitcoin::Amount,
     pub dai_reserved_funds: dai::Amount,
     btc_max_sell_amount: Option<bitcoin::Amount>,

--- a/src/maker.rs
+++ b/src/maker.rs
@@ -234,7 +234,6 @@ pub enum TakeRequestDecision {
     GoForSwap,
     RateNotProfitable,
     InsufficientFunds,
-    CannotTradeWithTaker,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/src/network.rs
+++ b/src/network.rs
@@ -113,7 +113,7 @@ impl Swarm {
         self.inner.confirm(order)
     }
 
-    pub fn deny(&mut self, order: TakenOrder) -> anyhow::Result<()> {
+    pub fn deny(&mut self, order: TakenOrder) {
         self.inner.deny(order)
     }
 
@@ -204,13 +204,9 @@ impl Nectar {
         Ok(())
     }
 
-    fn deny(&mut self, order: TakenOrder) -> anyhow::Result<()> {
-        self.active_takers.remove(&order.taker)?;
-
+    fn deny(&mut self, order: TakenOrder) {
         self.orderbook
-            .deny(order.taker.peer_id(), order.id, order.confirmation_channel);
-
-        Ok(())
+            .deny(order.taker.peer_id(), order.id, order.confirmation_channel)
     }
 
     /// Save the swap identities and send them to the taker


### PR DESCRIPTION
Given that we only free funds once the swap execution is over, we need to make sure that we always reserve funds before respawning (since the `Maker`'s state is lost between restarts of Nectar).

Additionally, we could examine swaps and decide whether we have enough money or not to continue with the execution successfully, but it would be quite complex. Instead, we let the swap execution fail, which is functionally equivalent to preventing the respawn.

---

There is a second patch which makes it so that `deny` doesn't try to remove the order's taker from the set of `ActiveTaker`s, as @da-kami  correctly suggested in his review of PR #59.