### PR TITLE
Ask Ethereum node for gas price

### DIFF
--- a/src/bitcoin/wallet.rs
+++ b/src/bitcoin/wallet.rs
@@ -1,16 +1,15 @@
-use crate::bitcoin::{Address, Amount, Client, Network, WalletInfoResponse};
-use crate::seed::Seed;
+use crate::{
+    bitcoin::{Address, Amount, Client, Network, WalletInfoResponse},
+    seed::Seed,
+};
 use ::bitcoin::{
     hash_types::PubkeyHash,
-    hashes::Hash,
-    hashes::{sha512, HashEngine, Hmac, HmacEngine},
-    secp256k1,
-    secp256k1::SecretKey,
-    util::bip32::ExtendedPrivKey,
+    hashes::{sha512, Hash, HashEngine, Hmac, HmacEngine},
+    secp256k1::{self, SecretKey},
+    util::bip32::{ChainCode, ExtendedPrivKey},
     PrivateKey, Transaction, Txid,
 };
 use anyhow::Context;
-use bitcoin::util::bip32::ChainCode;
 use rand::RngCore;
 use sha2::{Digest, Sha256};
 use std::path::Path;

--- a/src/ethereum/geth.rs
+++ b/src/ethereum/geth.rs
@@ -169,6 +169,21 @@ impl Client {
 
         Ok(amount)
     }
+
+    pub async fn gas_price(&self) -> anyhow::Result<num256::Uint256> {
+        let amount = self
+            .rpc_client
+            .send::<Vec<()>, String>(jsonrpc::Request::new(
+                "eth_gasPrice",
+                vec![],
+                JSONRPC_VERSION.into(),
+            ))
+            .await
+            .context("failed to get gas price")?;
+        let amount = num256::Uint256::from_str_radix(&amount[2..], 16)?;
+
+        Ok(amount)
+    }
 }
 
 fn balance_of_fn(account: Address) -> anyhow::Result<Vec<u8>> {

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -414,6 +414,15 @@ mod tests {
             let ethereum_wallet =
                 crate::ethereum::Wallet::new(seed, ethereum_node_url.clone(), token_contract)?;
 
+            // mint ether to pay for gas
+            ethereum_blockchain
+                .mint_ether(
+                    ethereum_wallet.account(),
+                    1_000_000_000_000_000_000u64,
+                    ethereum_chain_id,
+                )
+                .await?;
+
             (
                 bitcoin::Wallet {
                     inner: Arc::new(bitcoin_wallet),
@@ -434,9 +443,18 @@ mod tests {
                 crate::ethereum::Wallet::new(seed, ethereum_node_url, token_contract)?;
 
             ethereum_blockchain
-                .mint(
+                .mint_erc20_token(
                     ethereum_wallet.account(),
                     asset::Erc20::new(token_contract, Erc20Quantity::from_wei(5_000_000_000u64)),
+                    ethereum_chain_id,
+                )
+                .await?;
+
+            // mint ether to pay for gas
+            ethereum_blockchain
+                .mint_ether(
+                    ethereum_wallet.account(),
+                    1_000_000_000_000_000_000u64,
                     ethereum_chain_id,
                 )
                 .await?;

--- a/src/swap/ethereum.rs
+++ b/src/swap/ethereum.rs
@@ -14,14 +14,6 @@ pub struct Wallet {
     pub connector: Arc<comit::btsieve::ethereum::Web3Connector>,
 }
 
-impl Wallet {
-    pub async fn refund(&self, action: herc20::CallContract) -> anyhow::Result<()> {
-        let _ = self.inner.call_contract(action).await?;
-
-        Ok(())
-    }
-}
-
 #[async_trait::async_trait]
 impl herc20::ExecuteDeploy for Wallet {
     async fn execute_deploy(&self, params: herc20::Params) -> anyhow::Result<herc20::Deployed> {

--- a/src/test_harness/ethereum.rs
+++ b/src/test_harness/ethereum.rs
@@ -1,5 +1,4 @@
-use crate::ethereum;
-use crate::ethereum::Client;
+use crate::ethereum::{self, Client};
 use anyhow::Context;
 use clarity::PrivateKey;
 use comit::{
@@ -94,7 +93,21 @@ impl<'c> Blockchain<'c> {
         })
     }
 
-    pub async fn mint(&self, to: Address, asset: Erc20, chain_id: ChainId) -> anyhow::Result<()> {
+    pub async fn mint_ether(&self, to: Address, wei: u64, chain_id: ChainId) -> anyhow::Result<()> {
+        let _ = self
+            .dev_account_wallet
+            .send_transaction(to, wei, 100_000, None, chain_id)
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn mint_erc20_token(
+        &self,
+        to: Address,
+        asset: Erc20,
+        chain_id: ChainId,
+    ) -> anyhow::Result<()> {
         let transfer = self.transfer_fn(to, asset.quantity)?;
 
         let _ = self


### PR DESCRIPTION
We used to hard-code the gas price of transactions to 0 because it worked for a local development node (as proven by the swap execution integration test passing before these changes). Obviously, this wouldn't work in the real world. Using `eth_gasPrice` we ask the Ethereum node to give us a gas price that should be good enough.

This caused the swap execution integration test to fail, which was fixed by minting ether for Alice and Bob.