### PR TITLE
Ask node for gas limit estimate for Wallet::send_transaction

### DIFF
--- a/src/test_harness/ethereum.rs
+++ b/src/test_harness/ethereum.rs
@@ -96,7 +96,7 @@ impl<'c> Blockchain<'c> {
     pub async fn mint_ether(&self, to: Address, wei: u64, chain_id: ChainId) -> anyhow::Result<()> {
         let _ = self
             .dev_account_wallet
-            .send_transaction(to, wei, 100_000, None, chain_id)
+            .send_transaction(to, wei, Some(100_000), None, chain_id)
             .await?;
 
         Ok(())
@@ -112,7 +112,13 @@ impl<'c> Blockchain<'c> {
 
         let _ = self
             .dev_account_wallet
-            .send_transaction(asset.token_contract, 0, 100_000, Some(transfer), chain_id)
+            .send_transaction(
+                asset.token_contract,
+                0,
+                Some(100_000),
+                Some(transfer),
+                chain_id,
+            )
             .await?;
 
         Ok(())


### PR DESCRIPTION
- Introduce ethereum::Wallet::gas_limit to do so.
- Remove unused geth::send_transaction. We always sign the transaction
  locally and broadcast a raw transaction.