### PR TITLE
Implement `nectar withdraw` for Ether and Bitcoin

### DIFF
--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -5,7 +5,7 @@ mod bitcoind;
 mod wallet;
 
 use crate::float_maths::string_int_to_float;
-pub use ::bitcoin::{Address, Network};
+pub use ::bitcoin::{Address, Network, Txid};
 pub use bitcoind::*;
 use std::fmt;
 pub use wallet::Wallet;

--- a/src/bitcoin/wallet.rs
+++ b/src/bitcoin/wallet.rs
@@ -24,7 +24,7 @@ pub struct Wallet {
     name: String,
     bitcoind_client: Client,
     seed: Seed,
-    network: Network,
+    pub network: Network,
 }
 
 impl Wallet {

--- a/src/command.rs
+++ b/src/command.rs
@@ -5,12 +5,17 @@ mod balance;
 mod deposit;
 mod trade;
 mod wallet_info;
+mod withdraw;
 
+use crate::bitcoin;
 use crate::config::{File, Settings};
+use crate::ethereum::{self, dai, ether};
 pub use balance::*;
 pub use deposit::*;
+use std::str::FromStr;
 pub use trade::*;
 pub use wallet_info::*;
+pub use withdraw::*;
 
 #[derive(StructOpt, Debug)]
 pub struct Options {
@@ -28,13 +33,14 @@ impl Options {
     }
 }
 
-#[derive(StructOpt, Debug, Copy, Clone)]
+#[derive(StructOpt, Debug, Clone)]
 pub enum Command {
     Trade,
     WalletInfo,
     Balance,
     Deposit,
     DumpConfig,
+    Withdraw(Withdraw),
 }
 
 pub fn dump_config(settings: Settings) -> anyhow::Result<()> {
@@ -42,4 +48,43 @@ pub fn dump_config(settings: Settings) -> anyhow::Result<()> {
     let serialized = toml::to_string(&file)?;
     println!("{}", serialized);
     Ok(())
+}
+
+// TODO: This takes the nominal amount (ether, bitcoin, dai)
+// We could add more option to accept the smallest unit (wei, sats, attodai)
+#[derive(StructOpt, Debug, Clone)]
+pub enum Withdraw {
+    Btc {
+        #[structopt(parse(try_from_str = parse_bitcoin))]
+        amount: bitcoin::Amount,
+        to_address: bitcoin::Address,
+    },
+    Dai {
+        #[structopt(parse(try_from_str = parse_dai))]
+        amount: dai::Amount,
+        to_address: ethereum::Address,
+    },
+    Eth {
+        #[structopt(parse(try_from_str = parse_ether))]
+        amount: ether::Amount,
+        to_address: ethereum::Address,
+    },
+}
+
+fn parse_bitcoin(str: &str) -> anyhow::Result<bitcoin::Amount> {
+    // TODO: In addition to providing an interface to withdraw satoshi, we could use string instead of
+    // float here
+    let btc = f64::from_str(str)?;
+    bitcoin::Amount::from_btc(btc)
+}
+
+fn parse_dai(str: &str) -> anyhow::Result<dai::Amount> {
+    // TODO: In addition to providing an interface to withdraw attodai, we could use string instead of
+    // float here
+    let dai = f64::from_str(str)?;
+    dai::Amount::from_dai_trunc(dai)
+}
+
+fn parse_ether(str: &str) -> anyhow::Result<ether::Amount> {
+    ether::Amount::from_ether_str(str)
 }

--- a/src/command/withdraw.rs
+++ b/src/command/withdraw.rs
@@ -1,0 +1,115 @@
+use crate::command::Withdraw;
+use crate::ethereum::STANDARD_ETH_TRANSFER_GAS_LIMIT;
+use crate::{bitcoin, ethereum};
+
+pub async fn withdraw(
+    ethereum_wallet: ethereum::Wallet,
+    bitcoin_wallet: bitcoin::Wallet,
+    arguments: Withdraw,
+) -> anyhow::Result<String> {
+    match arguments {
+        Withdraw::Btc { amount, to_address } => {
+            let tx_id = bitcoin_wallet
+                .send_to_address(to_address.clone(), amount, bitcoin_wallet.network)
+                .await?;
+            Ok(format!(
+                "{} transferred to {}\nTransaction id: {}",
+                amount, to_address, tx_id
+            ))
+        }
+        Withdraw::Dai { .. } => todo!(),
+        Withdraw::Eth { amount, to_address } => {
+            let tx_id = ethereum_wallet
+                .send_transaction(
+                    to_address,
+                    amount.clone(),
+                    Some(STANDARD_ETH_TRANSFER_GAS_LIMIT),
+                    None,
+                    ethereum_wallet.chain_id,
+                )
+                .await?;
+            Ok(format!(
+                "{} transferred to {}\nTransaction id: {}",
+                amount, to_address, tx_id
+            ))
+        }
+    }
+}
+
+#[cfg(all(test, feature = "test-docker"))]
+mod tests {
+    use super::*;
+    use crate::ethereum::{ether, ChainId};
+    use crate::{test_harness, Seed};
+    use std::str::FromStr;
+
+    // Run cargo test with `--ignored --nocapture` to see the `println output`
+    #[ignore]
+    #[tokio::test]
+    async fn withdraw_command() {
+        let client = testcontainers::clients::Cli::default();
+        let seed = Seed::random().unwrap();
+
+        let bitcoin_blockchain = test_harness::bitcoin::Blockchain::new(&client).unwrap();
+        bitcoin_blockchain.init().await.unwrap();
+
+        let bitcoin_wallet = bitcoin::Wallet::new(
+            seed,
+            bitcoin_blockchain.node_url.clone(),
+            ::bitcoin::Network::Regtest,
+        )
+        .await
+        .unwrap();
+
+        let bitcoin_address = bitcoin_wallet.new_address().await.unwrap();
+        bitcoin_blockchain
+            .mint(bitcoin_address, bitcoin::Amount::from_btc(1.2).unwrap())
+            .await
+            .unwrap();
+
+        let mut ethereum_blockchain = test_harness::ethereum::Blockchain::new(&client).unwrap();
+        ethereum_blockchain.init().await.unwrap();
+
+        let ethereum_wallet = crate::ethereum::Wallet::new(
+            seed,
+            ethereum_blockchain.node_url.clone(),
+            ethereum_blockchain.token_contract().unwrap(),
+            ChainId::regtest(),
+        )
+        .await
+        .unwrap();
+
+        let ethereum_address = ethereum_wallet.account();
+        ethereum_blockchain
+            .mint_ether(
+                ethereum_address,
+                ether::Amount::from_ether_str("10").unwrap(),
+                ChainId::regtest(),
+            )
+            .await
+            .unwrap();
+
+        let bitcoin_withdraw = Withdraw::Btc {
+            amount: bitcoin::Amount::from_btc(0.3).unwrap(),
+            to_address: bitcoin::Address::from_str("bcrt1qk60fmayw8xrtqd4ru2ut8kgv08wyqpdzqkj55h")
+                .unwrap(),
+        };
+        let stdout = withdraw(
+            ethereum_wallet.clone(),
+            bitcoin_wallet.clone(),
+            bitcoin_withdraw,
+        )
+        .await
+        .unwrap();
+        println!("{}", stdout);
+
+        let ether_withdraw = Withdraw::Eth {
+            amount: ether::Amount::from_ether_str("2.4").unwrap(),
+            to_address: ethereum::Address::random(),
+        };
+        let stdout = withdraw(ethereum_wallet, bitcoin_wallet, ether_withdraw)
+            .await
+            .unwrap();
+        println!("{}", stdout);
+    }
+}

--- a/src/config/serde/ethereum_address.rs
+++ b/src/config/serde/ethereum_address.rs
@@ -1,15 +1,15 @@
-use crate::swap::ethereum;
+use crate::ethereum::Address;
 use serde::{de, export::fmt, Deserialize, Deserializer, Serializer};
 use std::str::FromStr;
 
-pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<ethereum::Address>, D::Error>
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Address>, D::Error>
 where
     D: Deserializer<'de>,
 {
     struct Visitor;
 
     impl<'de> de::Visitor<'de> for Visitor {
-        type Value = Option<ethereum::Address>;
+        type Value = Option<Address>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
             formatter.write_str("an ethereum address")
@@ -28,14 +28,12 @@ where
         {
             let s: Option<&str> = Option::deserialize(deserializer)?;
             match s {
-                Some(value) => Ok(Some(ethereum::Address::from_str(value).map_err(
-                    |error| {
-                        serde::de::Error::custom(format!(
-                            "Could not deserialize ethereum address: {:?}",
-                            error
-                        ))
-                    },
-                )?)),
+                Some(value) => Ok(Some(Address::from_str(value).map_err(|error| {
+                    serde::de::Error::custom(format!(
+                        "Could not deserialize ethereum address: {:?}",
+                        error
+                    ))
+                })?)),
                 None => Ok(None),
             }
         }
@@ -44,7 +42,7 @@ where
         where
             E: de::Error,
         {
-            Ok(Some(ethereum::Address::from_str(v).map_err(|error| {
+            Ok(Some(Address::from_str(v).map_err(|error| {
                 E::custom(format!(
                     "Could not deserialize ethereum address: {:?}",
                     error
@@ -56,7 +54,7 @@ where
     deserializer.deserialize_any(Visitor)
 }
 
-pub fn serialize<S>(value: &Option<ethereum::Address>, serializer: S) -> Result<S::Ok, S::Error>
+pub fn serialize<S>(value: &Option<Address>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {

--- a/src/ethereum.rs
+++ b/src/ethereum.rs
@@ -2,6 +2,7 @@ pub mod dai;
 mod geth;
 mod wallet;
 
+pub use comit::ethereum::{Address, ChainId};
 pub use geth::Client;
 pub use wallet::Wallet;
 

--- a/src/ethereum.rs
+++ b/src/ethereum.rs
@@ -2,9 +2,11 @@ pub mod dai;
 mod geth;
 mod wallet;
 
-pub use comit::ethereum::{Address, ChainId};
+pub use comit::ethereum::{Address, ChainId, Hash};
 pub use geth::Client;
 pub use wallet::Wallet;
+
+pub const STANDARD_ETH_TRANSFER_GAS_LIMIT: u64 = 21_000;
 
 pub mod ether {
     use crate::float_maths::multiply_pow_ten;
@@ -83,7 +85,7 @@ pub mod ether {
         }
     }
 
-    /// Accepts decimal string
+    /// Accepts decimal string of wei
     impl FromStr for Amount {
         type Err = comit::asset::ethereum::Error;
 

--- a/src/ethereum/dai.rs
+++ b/src/ethereum/dai.rs
@@ -108,7 +108,8 @@ impl Amount {
 
         let dai = truncate(dai, ATTOS_IN_DAI_EXP);
 
-        let u_int_value = multiply_pow_ten(dai, ATTOS_IN_DAI_EXP).expect("It is truncated");
+        let u_int_value =
+            multiply_pow_ten(&dai.to_string(), ATTOS_IN_DAI_EXP).expect("It is truncated");
 
         Ok(Amount(u_int_value))
     }

--- a/src/ethereum/geth.rs
+++ b/src/ethereum/geth.rs
@@ -1,10 +1,10 @@
-use crate::ethereum::ether;
+use crate::ethereum::{ether, Address};
 use crate::jsonrpc;
 use anyhow::Context;
 use asset::Erc20Quantity;
 use comit::{
     asset::{self, ethereum::TryFromWei},
-    ethereum::{Address, ChainId, Hash, Transaction, TransactionReceipt},
+    ethereum::{ChainId, Hash, Transaction, TransactionReceipt},
 };
 use ethereum_types::U256;
 use num::{BigUint, Num};

--- a/src/ethereum/wallet.rs
+++ b/src/ethereum/wallet.rs
@@ -2,13 +2,14 @@ use crate::{
     ethereum::{
         dai, ether,
         geth::{Client, EstimateGasRequest},
+        Address, ChainId,
     },
     Seed,
 };
 use comit::{
     actions::ethereum::{CallContract, DeployContract},
     asset::Erc20,
-    ethereum::{Address, ChainId, Hash, TransactionReceipt},
+    ethereum::{Hash, TransactionReceipt},
 };
 use num::BigUint;
 use url::Url;
@@ -25,7 +26,7 @@ impl Wallet {
     pub async fn new(
         seed: Seed,
         url: Url,
-        dai_contract_addr: comit::ethereum::Address,
+        dai_contract_addr: Address,
         chain_id: ChainId,
     ) -> anyhow::Result<Self> {
         let private_key = clarity::PrivateKey::from_slice(&seed.bytes())
@@ -127,7 +128,7 @@ impl Wallet {
         value: ether::Amount,
         gas_limit: Option<u64>,
         data: Option<Vec<u8>>,
-        chain_id: comit::ethereum::ChainId,
+        chain_id: ChainId,
     ) -> anyhow::Result<Hash> {
         self.assert_chain(chain_id).await?;
 

--- a/src/ethereum/wallet.rs
+++ b/src/ethereum/wallet.rs
@@ -2,14 +2,14 @@ use crate::{
     ethereum::{
         dai, ether,
         geth::{Client, EstimateGasRequest},
-        Address, ChainId,
+        Address, ChainId, Hash,
     },
     Seed,
 };
 use comit::{
     actions::ethereum::{CallContract, DeployContract},
     asset::Erc20,
-    ethereum::{Hash, TransactionReceipt},
+    ethereum::TransactionReceipt,
 };
 use num::BigUint;
 use url::Url;
@@ -19,7 +19,7 @@ pub struct Wallet {
     private_key: clarity::PrivateKey,
     geth_client: Client,
     dai_contract_addr: Address,
-    chain_id: ChainId,
+    pub chain_id: ChainId,
 }
 
 impl Wallet {
@@ -121,7 +121,6 @@ impl Wallet {
         Ok(hash)
     }
 
-    #[cfg(test)]
     pub async fn send_transaction(
         &self,
         to: Address,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use nectar::{
     bitcoin,
-    command::{balance, deposit, dump_config, trade, wallet_info, Command, Options},
+    command::{balance, deposit, dump_config, trade, wallet_info, withdraw, Command, Options},
     config::{self, Settings},
     ethereum,
 };
@@ -64,6 +64,12 @@ async fn main() {
         Command::Deposit => {
             let deposit = deposit(ethereum_wallet, bitcoin_wallet).await.unwrap();
             println!("{}", deposit);
+        }
+        Command::Withdraw(arguments) => {
+            let tx_id = withdraw(ethereum_wallet, bitcoin_wallet, arguments)
+                .await
+                .unwrap();
+            println!("Withdraw successful. Transaction Id: {}", tx_id);
         }
         Command::DumpConfig => unreachable!(),
     }

--- a/src/test_harness/ethereum.rs
+++ b/src/test_harness/ethereum.rs
@@ -1,10 +1,9 @@
-use crate::ethereum::{self, ether, Client};
+use crate::ethereum::{self, ether, Address, ChainId, Client};
 use anyhow::Context;
 use clarity::PrivateKey;
 use comit::{
     actions::ethereum::DeployContract,
     asset::{Erc20, Erc20Quantity, Ether},
-    ethereum::{Address, ChainId},
 };
 use num256::Uint256;
 use std::str::FromStr;


### PR DESCRIPTION
Almost there, getting the following error:
```
thread 'command::withdraw::tests::withdraw_command' panicked at 'called `Result::unwrap()` on an `Err` value: failed to get gas price

Caused by:
    0: JSON-RPC request Request { id: "1", jsonrpc: "2.0", method: "eth_estimateGas", params: [Object({"gas_price": String("1"), "to": String("0x0000000000000000000000000000000000000000"), "value": String("0x214e8348c4f00000")})] } failed
    1: JSON-RPC request failed with code -32000: gas required exceeds allowance (6320079) or always failing transaction', src/command/withdraw.rs:109:22
```