### PR TITLE
Upgrade to latest version of COMIT lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,13 @@ jobs:
         uses: actions/cache@v1
         with:
           path: target
-          key: ${{ matrix.os }}-rust-${{ env.RUST_TOOLCHAIN }}-target-directory-${{ hashFiles('Cargo.lock') }}-v2
+          key: ${{ matrix.os }}-rust-${{ env.RUST_TOOLCHAIN }}-target-directory-${{ hashFiles('Cargo.lock') }}-v3
 
       - name: Cache ~/.cargo/registry directory
         uses: actions/cache@v1
         with:
           path: ~/.cargo/registry
-          key: ${{ matrix.os }}-rust-${{ env.RUST_TOOLCHAIN }}-cargo-registry-directory-${{ hashFiles('Cargo.lock') }}-v2
+          key: ${{ matrix.os }}-rust-${{ env.RUST_TOOLCHAIN }}-cargo-registry-directory-${{ hashFiles('Cargo.lock') }}-v3
 
       - name: Cargo check ${{ matrix.os }}
         run: cargo check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 [[package]]
 name = "comit"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/comit-rs?branch=nectar#57c9556ae859b14735dfcac23e0138004df48e6b"
+source = "git+https://github.com/comit-network/comit-rs?branch=nectar-new-orderbook#4c3d6c9b289cc5db5ba4df6641ab17c2253cd185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -510,7 +510,7 @@ dependencies = [
  "hex 0.4.2",
  "lazy_static",
  "levenshtein",
- "libp2p",
+ "libp2p 0.22.0",
  "lru 0.5.3",
  "num 0.3.0",
  "primitive-types",
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "digest"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/comit-rs?branch=nectar#57c9556ae859b14735dfcac23e0138004df48e6b"
+source = "git+https://github.com/comit-network/comit-rs?branch=nectar-new-orderbook#4c3d6c9b289cc5db5ba4df6641ab17c2253cd185"
 dependencies = [
  "digest-macro-derive",
  "hex 0.4.2",
@@ -763,7 +763,7 @@ dependencies = [
 [[package]]
 name = "digest-macro-derive"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/comit-rs?branch=nectar#57c9556ae859b14735dfcac23e0138004df48e6b"
+source = "git+https://github.com/comit-network/comit-rs?branch=nectar-new-orderbook#4c3d6c9b289cc5db5ba4df6641ab17c2253cd185"
 dependencies = [
  "hex 0.4.2",
  "proc-macro2 1.0.18",
@@ -1528,6 +1528,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0306a49ee6a89468f96089906f36b0eef82c988dcfc8acf3e2dcd6ad1c859f85"
+dependencies = [
+ "bytes",
+ "futures",
+ "lazy_static",
+ "libp2p-core",
+ "libp2p-core-derive",
+ "libp2p-gossipsub",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "multihash",
+ "parity-multiaddr",
+ "parking_lot 0.10.2",
+ "pin-project",
+ "smallvec 1.4.1",
+ "wasm-timer",
+]
+
+[[package]]
 name = "libp2p-core"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,7 +1977,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "hex 0.4.2",
- "libp2p",
+ "libp2p 0.21.1",
  "log",
  "num 0.3.0",
  "num256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ bimap = "0.4"
 bitcoin = { version = "0.23.0", features = ["rand", "use-serde"] }
 chrono = "0.4"
 clarity = "0.1"
-comit = { git = "https://github.com/comit-network/comit-rs", package = "comit", branch = "nectar" }
+comit = { git = "https://github.com/comit-network/comit-rs", package = "comit", branch = "nectar-new-orderbook" }
 config = "0.10"
 conquer-once = "0.2"
 csv = "1.1"

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -3,6 +3,6 @@ mod bitcoind;
 mod wallet;
 
 pub use ::bitcoin::{Address, Network, Txid};
-pub use amount::{Amount, SATS_IN_BITCOIN_EXP};
+pub use amount::{Amount, Asset, SATS_IN_BITCOIN_EXP};
 pub use bitcoind::*;
 pub use wallet::Wallet;

--- a/src/bitcoin/amount.rs
+++ b/src/bitcoin/amount.rs
@@ -3,8 +3,15 @@ use crate::{
     float_maths::string_int_to_float,
     Rate,
 };
+use bitcoin::Network;
 
 pub const SATS_IN_BITCOIN_EXP: u16 = 8;
+
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, PartialEq, Eq)]
+pub struct Asset {
+    pub amount: Amount,
+    pub network: Network,
+}
 
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, PartialEq, Eq, Default)]
 pub struct Amount(::bitcoin::Amount);
@@ -97,6 +104,16 @@ impl std::fmt::Display for Amount {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let bitcoin = string_int_to_float(self.as_sat().to_string(), SATS_IN_BITCOIN_EXP as usize);
         write!(f, "{} BTC", bitcoin)
+    }
+}
+
+#[cfg(test)]
+impl Default for Asset {
+    fn default() -> Self {
+        Self {
+            amount: Amount::default(),
+            network: Network::Bitcoin,
+        }
     }
 }
 

--- a/src/command/trade.rs
+++ b/src/command/trade.rs
@@ -174,6 +174,8 @@ async fn init_maker(
         initial_rate,
         spread,
         settings.ethereum.dai_contract_address,
+        settings.bitcoin.network,
+        settings.ethereum.chain_id,
     ))
 }
 

--- a/src/ethereum/dai.rs
+++ b/src/ethereum/dai.rs
@@ -219,8 +219,14 @@ impl std::ops::Sub for Amount {
 
 impl From<Erc20> for Amount {
     fn from(erc20: Erc20) -> Self {
-        let quantity = BigUint::from_bytes_le(erc20.quantity.to_bytes().as_slice());
-        Amount { 0: quantity }
+        erc20.quantity.into()
+    }
+}
+
+impl From<Erc20Quantity> for Amount {
+    fn from(erc20_quantity: Erc20Quantity) -> Self {
+        let quantity = BigUint::from_bytes_le(erc20_quantity.to_bytes().as_slice());
+        Amount(quantity)
     }
 }
 

--- a/src/ethereum/dai.rs
+++ b/src/ethereum/dai.rs
@@ -42,10 +42,13 @@ static DAI_CONTRACT_ADDRESS_ROPSTEN: Lazy<Address> = Lazy::new(|| {
         .unwrap()
 });
 
+// TODO: There is duplicated information between `contract_address`
+// and `chain_id` that can be avoided.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Asset {
     pub amount: Amount,
     pub contract_address: DaiContractAddress,
+    pub chain_id: ChainId,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/maker.rs
+++ b/src/maker.rs
@@ -2,7 +2,10 @@
 
 use crate::{
     bitcoin,
-    ethereum::dai::{self, DaiContractAddress},
+    ethereum::{
+        self,
+        dai::{self, DaiContractAddress},
+    },
     network::{self, Taker},
     order::{BtcDaiOrder, Position, Symbol},
     rate::Spread,
@@ -34,6 +37,8 @@ pub struct Maker {
     mid_market_rate: Option<MidMarketRate>,
     spread: Spread,
     dai_contract_address: DaiContractAddress,
+    bitcoin_network: bitcoin::Network,
+    ethereum_network: ethereum::ChainId,
 }
 
 impl Maker {
@@ -47,6 +52,8 @@ impl Maker {
         mid_market_rate: MidMarketRate,
         spread: Spread,
         dai_contract_address: DaiContractAddress,
+        bitcoin_network: bitcoin::Network,
+        ethereum_network: ethereum::ChainId,
     ) -> Self {
         Maker {
             btc_balance: Some(btc_balance),
@@ -59,6 +66,8 @@ impl Maker {
             mid_market_rate: Some(mid_market_rate),
             spread,
             dai_contract_address,
+            bitcoin_network,
+            ethereum_network,
         }
     }
 
@@ -135,6 +144,7 @@ impl Maker {
                 mid_market_rate.into(),
                 self.spread,
                 self.dai_contract_address,
+                self.ethereum_network,
             ),
             (None, _) => anyhow::bail!(RateNotAvailable(Position::Sell)),
             (_, None) => anyhow::bail!(BalanceNotAvailable(Symbol::Btc)),
@@ -150,6 +160,7 @@ impl Maker {
                 mid_market_rate.into(),
                 self.spread,
                 self.dai_contract_address,
+                self.ethereum_network,
             ),
             (None, _) => anyhow::bail!(RateNotAvailable(Position::Buy)),
             (_, None) => anyhow::bail!(BalanceNotAvailable(Symbol::Dai)),
@@ -272,6 +283,7 @@ mod tests {
         order::{BtcDaiOrder, Position},
         MidMarketRate, Rate,
     };
+    use comit::ethereum::ChainId;
     use std::convert::TryFrom;
 
     impl Default for Maker {
@@ -287,6 +299,8 @@ mod tests {
                 mid_market_rate: Some(MidMarketRate::default()),
                 spread: Spread::default(),
                 dai_contract_address: DaiContractAddress::Mainnet,
+                bitcoin_network: bitcoin::Network::Bitcoin,
+                ethereum_network: ethereum::ChainId::mainnet(),
             }
         }
     }
@@ -328,6 +342,7 @@ mod tests {
         dai::Asset {
             amount,
             contract_address: DaiContractAddress::Mainnet,
+            chain_id: ChainId::mainnet(),
         }
     }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -445,16 +445,19 @@ impl TakenOrder {
         taker: Taker,
         confirmation_channel: ResponseChannel<take_order::Response>,
     ) -> Self {
+        let base = bitcoin::Asset {
+            amount: order.bitcoin_amount.into(),
+            network: order.bitcoin_ledger.into(),
+        };
         let contract_address = DaiContractAddress::local(order.token_contract);
         let quote = dai::Asset {
             amount: order.ethereum_amount.into(),
             contract_address,
             chain_id: order.ethereum_ledger.chain_id,
         };
-
         let inner = BtcDaiOrder {
             position: order.position.into(),
-            base: order.bitcoin_amount.into(),
+            base,
             quote,
         };
 
@@ -518,8 +521,8 @@ impl PublishOrder {
             id,
             maker: maker.into(),
             position: self.0.position.into(),
-            bitcoin_amount: self.0.base.into(),
-            bitcoin_ledger: bitcoin::Network::Regtest.into(), // TODO: Get it from the bitcoin Asset
+            bitcoin_amount: self.0.base.amount.into(),
+            bitcoin_ledger: self.0.base.network.into(),
             bitcoin_absolute_expiry: bitcoin_absolute_expiry.into(),
             ethereum_amount: self.0.quote.amount.into(),
             token_contract: self.0.quote.contract_address.into(),

--- a/src/network.rs
+++ b/src/network.rs
@@ -10,9 +10,7 @@ use crate::{
 use bimap::BiMap;
 use chrono::Utc;
 use comit::{
-    asset,
-    ethereum::ChainId,
-    identity,
+    asset, identity,
     network::{
         self,
         orderbook::{self, take_order, OrderId},
@@ -451,6 +449,7 @@ impl TakenOrder {
         let quote = dai::Asset {
             amount: order.ethereum_amount.into(),
             contract_address,
+            chain_id: order.ethereum_ledger.chain_id,
         };
 
         let inner = BtcDaiOrder {
@@ -524,7 +523,7 @@ impl PublishOrder {
             bitcoin_absolute_expiry: bitcoin_absolute_expiry.into(),
             ethereum_amount: self.0.quote.amount.into(),
             token_contract: self.0.quote.contract_address.into(),
-            ethereum_ledger: comit::ledger::Ethereum::new(ChainId::regtest()), // TODO: Get it from the dai Asset
+            ethereum_ledger: comit::ledger::Ethereum::new(self.0.quote.chain_id),
             ethereum_absolute_expiry: ethereum_absolute_expiry.into(),
         }
     }

--- a/src/network.rs
+++ b/src/network.rs
@@ -27,7 +27,6 @@ use libp2p::{
     swarm::{NetworkBehaviourAction, NetworkBehaviourEventProcess, PollParameters},
     NetworkBehaviour, PeerId,
 };
-use network::{SwapType, TradingPair};
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Digest, Sha256};
 use std::{
@@ -86,23 +85,6 @@ impl Swarm {
 
     pub fn as_inner(&mut self) -> &mut libp2p::Swarm<Nectar> {
         &mut self.inner
-    }
-
-    pub fn announce_btc_dai_trading_pair(&mut self) -> anyhow::Result<()> {
-        // The comit::network::Orderbook requires announcing the
-        // trading pair in both directions
-
-        self.inner.announce_trading_pair(TradingPair {
-            buy: SwapType::Hbit,
-            sell: SwapType::Herc20,
-        })?;
-
-        self.inner.announce_trading_pair(TradingPair {
-            buy: SwapType::Herc20,
-            sell: SwapType::Hbit,
-        })?;
-
-        Ok(())
     }
 
     pub fn publish(&mut self, order: PublishOrder) -> anyhow::Result<()> {
@@ -185,21 +167,19 @@ impl Nectar {
         }
     }
 
-    fn announce_trading_pair(&mut self, trading_pair: TradingPair) -> anyhow::Result<()> {
-        self.orderbook.announce_trading_pair(trading_pair)
-    }
-
     fn make(&mut self, order: PublishOrder) -> anyhow::Result<()> {
-        let order = orderbook::Order::new(self.local_peer_id.clone(), order.into());
-        let _order_id = self.orderbook.make(order)?;
+        let order_id = OrderId::random();
+        let order = order.into_orderbook_order(order_id, self.local_peer_id.clone());
+        let _ = self.orderbook.make(order)?;
 
         Ok(())
     }
 
     fn confirm(&mut self, order: TakenOrder) -> anyhow::Result<()> {
-        self.active_takers.insert(order.taker)?;
+        self.active_takers.insert(order.taker.clone())?;
 
-        self.orderbook.confirm(order.id, order.confirmation_channel);
+        self.orderbook
+            .confirm(order.id, order.confirmation_channel, order.taker.peer_id());
 
         Ok(())
     }
@@ -310,21 +290,14 @@ impl NetworkBehaviourEventProcess<orderbook::BehaviourOutEvent> for Nectar {
             orderbook::BehaviourOutEvent::TakeOrderConfirmation {
                 order_id,
                 shared_swap_id,
+                peer_id: taker_peer_id,
             } => {
-                let taker_peer_id = match self.takers.get(&order_id) {
-                    Some(taker) => taker,
-                    None => {
-                        tracing::warn!("unknown taker for order: {}", order_id,);
-                        return;
-                    }
-                };
-
                 self.order_swap_ids.insert(order_id, shared_swap_id);
 
                 self.events
                     .push_back(Event::SetSwapIdentities(SwapMetadata {
                         shared_swap_id,
-                        taker_peer_id: taker_peer_id.clone(),
+                        taker_peer_id,
                     }))
             }
             orderbook::BehaviourOutEvent::Failed { peer_id, order_id } => tracing::warn!(
@@ -389,35 +362,14 @@ impl NetworkBehaviourEventProcess<network::comit::BehaviourOutEvent> for Nectar 
                     }
                 };
 
-                // TODO: Handle sell orders when orderbook supports them
-                let (
-                    network::Order {
-                        buy: satoshi_amount,
-                        sell: erc20_asset,
-                        absolute_expiry,
-                        ..
+                let order = match self.order_swap_ids.get_by_right(&shared_swap_id) {
+                    Some(order_id) => match self.orderbook.get_order(order_id) {
+                        Some(order) => order,
+                        None => {
+                            tracing::warn!("could not find order with id, id: {}", order_id);
+                            return;
+                        }
                     },
-                    taker,
-                ) = match self.order_swap_ids.get_by_right(&shared_swap_id) {
-                    Some(order_id) => {
-                        let order = match self.orderbook.get_order(order_id) {
-                            Some(order) => order,
-                            None => {
-                                tracing::warn!("could not find order with id, id: {}", order_id);
-                                return;
-                            }
-                        };
-
-                        let taker = match self.takers.get(order_id) {
-                            Some(taker_peer_id) => Taker::new(taker_peer_id.clone()),
-                            None => {
-                                tracing::warn!("unknown taker for order: {}", order_id,);
-                                return;
-                            }
-                        };
-
-                        (order, taker)
-                    }
                     None => {
                         tracing::warn!(
                             "could order_id corresponding to shared_swap_id: {}",
@@ -427,29 +379,33 @@ impl NetworkBehaviourEventProcess<network::comit::BehaviourOutEvent> for Nectar 
                     }
                 };
 
-                // TODO: Handle expiries properly when orderbook does so
+                let taker = match self.takers.get(&order.id) {
+                    Some(taker_peer_id) => Taker::new(taker_peer_id.clone()),
+                    None => {
+                        tracing::warn!("unknown taker for order: {}", order.id,);
+                        return;
+                    }
+                };
 
                 let hbit_params = hbit::Params::new(
                     hbit::SharedParams {
-                        asset: asset::Bitcoin::from_sat(satoshi_amount),
+                        asset: order.bitcoin_amount,
                         redeem_identity: maker_bitcoin_identity,
                         refund_identity: taker_bitcoin_identity,
-                        expiry: Timestamp::from(absolute_expiry),
+                        expiry: order.bitcoin_absolute_expiry.into(),
                         secret_hash,
-                        // TODO: Make it dynamic when orderbook handles networks
-                        network: ::bitcoin::Network::Regtest,
+                        network: order.bitcoin_ledger.into(),
                     },
                     bitcoin_transient_sk,
                 );
 
                 let herc20_params = herc20::Params {
-                    asset: erc20_asset,
+                    asset: asset::Erc20::new(order.token_contract, order.ethereum_amount),
                     redeem_identity: taker_ethereum_identity,
                     refund_identity: maker_ethereum_identity,
-                    expiry: Timestamp::from(absolute_expiry),
+                    expiry: order.ethereum_absolute_expiry.into(),
                     secret_hash,
-                    // TODO: Make it dynamic once orderbook handles networks
-                    chain_id: ChainId::regtest(),
+                    chain_id: order.ethereum_ledger.chain_id,
                 };
 
                 let swap = SwapKind::HbitHerc20(SwapParams {
@@ -491,17 +447,15 @@ impl TakenOrder {
         taker: Taker,
         confirmation_channel: ResponseChannel<take_order::Response>,
     ) -> Self {
-        // TODO: comit::network::orderbook does not yet support selling Bitcoin
-
-        let contract_address = DaiContractAddress::local(order.sell.token_contract);
+        let contract_address = DaiContractAddress::local(order.token_contract);
         let quote = dai::Asset {
-            amount: order.sell.into(),
+            amount: order.ethereum_amount.into(),
             contract_address,
         };
 
         let inner = BtcDaiOrder {
-            position: Position::Buy,
-            base: bitcoin::Amount::from_sat(order.buy),
+            position: order.position.into(),
+            base: order.bitcoin_amount.into(),
             quote,
         };
 
@@ -547,36 +501,38 @@ impl Default for Taker {
 #[derive(Debug, Clone)]
 pub struct PublishOrder(BtcDaiOrder);
 
-impl From<BtcDaiOrder> for PublishOrder {
-    fn from(order: BtcDaiOrder) -> Self {
-        Self(order)
+impl PublishOrder {
+    fn into_orderbook_order(self, id: OrderId, maker: PeerId) -> comit::network::orderbook::Order {
+        // No special logic for expiry generation, other than setting
+        // the asset that will be alpha to be longer than the asset
+        // that will be beta
+        let twelve_hours = 12 * 60 * 60;
+        let beta_expiry = Timestamp::now().plus(twelve_hours);
+        let alpha_expiry = beta_expiry.plus(twelve_hours);
+
+        let (bitcoin_absolute_expiry, ethereum_absolute_expiry) = match self.0.position {
+            Position::Buy => (alpha_expiry, beta_expiry),
+            Position::Sell => (beta_expiry, alpha_expiry),
+        };
+
+        comit::network::orderbook::Order {
+            id,
+            maker: maker.into(),
+            position: self.0.position.into(),
+            bitcoin_amount: self.0.base.into(),
+            bitcoin_ledger: bitcoin::Network::Regtest.into(), // TODO: Get it from the bitcoin Asset
+            bitcoin_absolute_expiry: bitcoin_absolute_expiry.into(),
+            ethereum_amount: self.0.quote.amount.into(),
+            token_contract: self.0.quote.contract_address.into(),
+            ethereum_ledger: comit::ledger::Ethereum::new(ChainId::regtest()), // TODO: Get it from the dai Asset
+            ethereum_absolute_expiry: ethereum_absolute_expiry.into(),
+        }
     }
 }
 
-// We can remove this allow statement once the todo below is fixed
-#[allow(clippy::fallible_impl_from)]
-impl From<PublishOrder> for comit::network::orderbook::NewOrder {
-    fn from(from: PublishOrder) -> Self {
-        match from.0 {
-            BtcDaiOrder {
-                position: Position::Buy,
-                base,
-                quote,
-            } => Self {
-                buy: base.into(),
-                sell: asset::Erc20::new(quote.contract_address.into(), quote.amount.into()),
-                // TODO: comit::network::orderbook currently only
-                // supports defining one expiry. In cnd, this is used
-                // for both Alpha and Beta. Eventually we will need to
-                // handle this properly, but for now, let's set it to
-                // 24 hours in the future
-                absolute_expiry: Timestamp::now().plus(60 * 60 * 24).into(),
-            },
-            BtcDaiOrder {
-                position: Position::Sell,
-                ..
-            } => todo!("comit::network::orderbook does not yet support selling Bitcoin"),
-        }
+impl From<BtcDaiOrder> for PublishOrder {
+    fn from(order: BtcDaiOrder) -> Self {
+        Self(order)
     }
 }
 

--- a/src/order.rs
+++ b/src/order.rs
@@ -152,6 +152,24 @@ pub trait Fees {
     fn fees(&self) -> Self::Amount;
 }
 
+impl From<Position> for comit::network::Position {
+    fn from(from: Position) -> Self {
+        match from {
+            Position::Buy => comit::network::Position::Buy,
+            Position::Sell => comit::network::Position::Sell,
+        }
+    }
+}
+
+impl From<comit::network::Position> for Position {
+    fn from(from: comit::network::Position) -> Self {
+        match from {
+            comit::network::Position::Buy => Position::Buy,
+            comit::network::Position::Sell => Position::Sell,
+        }
+    }
+}
+
 #[cfg(test)]
 impl Default for BtcDaiOrder {
     fn default() -> Self {

--- a/src/order.rs
+++ b/src/order.rs
@@ -1,6 +1,9 @@
 use crate::{
     bitcoin,
-    ethereum::dai::{self, DaiContractAddress},
+    ethereum::{
+        self,
+        dai::{self, DaiContractAddress},
+    },
     MidMarketRate, Rate, Spread,
 };
 use std::{cmp::min, convert::TryFrom};
@@ -26,6 +29,7 @@ pub struct BtcDaiOrder {
 }
 
 impl BtcDaiOrder {
+    #[allow(clippy::too_many_arguments)]
     pub fn new_sell(
         base_balance: bitcoin::Amount,
         base_fees: bitcoin::Amount,
@@ -34,6 +38,7 @@ impl BtcDaiOrder {
         mid_market_rate: Rate,
         spread: Spread,
         dai_contract_address: DaiContractAddress,
+        chain_id: ethereum::ChainId,
     ) -> anyhow::Result<BtcDaiOrder> {
         if let Some(max_amount) = max_amount {
             if max_amount < base_fees {
@@ -61,6 +66,7 @@ impl BtcDaiOrder {
         let quote = dai::Asset {
             amount: quote_amount,
             contract_address: dai_contract_address,
+            chain_id,
         };
 
         Ok(BtcDaiOrder {
@@ -77,6 +83,7 @@ impl BtcDaiOrder {
         mid_market_rate: Rate,
         spread: Spread,
         dai_contract_address: DaiContractAddress,
+        chain_id: ethereum::ChainId,
     ) -> anyhow::Result<BtcDaiOrder> {
         if quote_balance <= quote_reserved_funds {
             anyhow::bail!(InsufficientFunds(Symbol::Dai))
@@ -93,6 +100,7 @@ impl BtcDaiOrder {
         let quote = dai::Asset {
             amount: quote_amount,
             contract_address: dai_contract_address,
+            chain_id,
         };
 
         Ok(BtcDaiOrder {
@@ -179,6 +187,7 @@ impl Default for BtcDaiOrder {
             quote: dai::Asset {
                 amount: dai::Amount::from_atto(num::BigUint::from(1u8)),
                 contract_address: DaiContractAddress::Mainnet,
+                chain_id: ethereum::ChainId::mainnet(),
             },
         }
     }
@@ -205,6 +214,7 @@ mod tests {
         dai::Asset {
             amount: dai_amount(dai),
             contract_address: DaiContractAddress::Mainnet,
+            chain_id: ethereum::ChainId::mainnet(),
         }
     }
 
@@ -219,6 +229,7 @@ mod tests {
             rate,
             Spread::new(0).unwrap(),
             DaiContractAddress::Mainnet,
+            ethereum::ChainId::mainnet(),
         )
         .unwrap();
 
@@ -231,6 +242,7 @@ mod tests {
             rate,
             Spread::new(0).unwrap(),
             DaiContractAddress::Mainnet,
+            ethereum::ChainId::mainnet(),
         )
         .unwrap();
 
@@ -248,6 +260,7 @@ mod tests {
             rate,
             Spread::new(0).unwrap(),
             DaiContractAddress::Mainnet,
+            ethereum::ChainId::mainnet(),
         )
         .unwrap();
 
@@ -260,6 +273,7 @@ mod tests {
             rate,
             Spread::new(0).unwrap(),
             DaiContractAddress::Mainnet,
+            ethereum::ChainId::mainnet(),
         )
         .unwrap();
 
@@ -277,6 +291,7 @@ mod tests {
             rate,
             Spread::new(0).unwrap(),
             DaiContractAddress::Mainnet,
+            ethereum::ChainId::mainnet(),
         )
         .unwrap();
 
@@ -289,6 +304,7 @@ mod tests {
             rate,
             Spread::new(0).unwrap(),
             DaiContractAddress::Mainnet,
+            ethereum::ChainId::mainnet(),
         )
         .unwrap();
 
@@ -305,6 +321,7 @@ mod tests {
             rate,
             Spread::new(0).unwrap(),
             DaiContractAddress::Mainnet,
+            ethereum::ChainId::mainnet(),
         )
         .unwrap();
 
@@ -324,6 +341,7 @@ mod tests {
             rate,
             spread,
             DaiContractAddress::Mainnet,
+            ethereum::ChainId::mainnet(),
         )
         .unwrap();
 
@@ -341,6 +359,7 @@ mod tests {
             rate,
             spread,
             DaiContractAddress::Mainnet,
+            ethereum::ChainId::mainnet(),
         )
         .unwrap();
 
@@ -355,6 +374,7 @@ mod tests {
             rate,
             spread,
             DaiContractAddress::Mainnet,
+            ethereum::ChainId::mainnet(),
         )
         .unwrap();
 
@@ -371,6 +391,7 @@ mod tests {
             rate,
             spread,
             DaiContractAddress::Mainnet,
+            ethereum::ChainId::mainnet(),
         )
         .unwrap();
 
@@ -391,6 +412,7 @@ mod tests {
             rate,
             spread,
             DaiContractAddress::Mainnet,
+            ethereum::ChainId::mainnet(),
         )
         .unwrap();
 
@@ -404,6 +426,7 @@ mod tests {
             rate,
             spread,
             DaiContractAddress::Mainnet,
+            ethereum::ChainId::mainnet(),
         )
         .unwrap();
 
@@ -424,6 +447,7 @@ mod tests {
             rate,
             spread,
             DaiContractAddress::Mainnet,
+            ethereum::ChainId::mainnet(),
         );
         assert!(result.unwrap_err().downcast::<InsufficientFunds>().is_ok());
 
@@ -434,6 +458,7 @@ mod tests {
             rate,
             spread,
             DaiContractAddress::Mainnet,
+            ethereum::ChainId::mainnet(),
         );
         assert!(result.unwrap_err().downcast::<InsufficientFunds>().is_ok());
     }
@@ -451,6 +476,7 @@ mod tests {
             rate,
             spread,
             DaiContractAddress::Mainnet,
+            ethereum::ChainId::mainnet(),
         );
         assert!(result.unwrap_err().downcast::<InsufficientFunds>().is_ok());
 
@@ -461,6 +487,7 @@ mod tests {
             rate,
             spread,
             DaiContractAddress::Mainnet,
+            ethereum::ChainId::mainnet(),
         );
         assert!(result.unwrap_err().downcast::<InsufficientFunds>().is_ok());
     }
@@ -564,7 +591,7 @@ mod tests {
                 let dai_reserved_funds = dai::Amount::from_atto(dai_reserved_funds);
                 let dai_max_amount = dai::Amount::from_atto(dai_max_amount);
 
-                let _: anyhow::Result<BtcDaiOrder> = BtcDaiOrder::new_buy(dai_balance, dai_reserved_funds, Some(dai_max_amount), rate, spread, DaiContractAddress::Mainnet,);
+                let _: anyhow::Result<BtcDaiOrder> = BtcDaiOrder::new_buy(dai_balance, dai_reserved_funds, Some(dai_max_amount), rate, spread, DaiContractAddress::Mainnet, ethereum::ChainId::mainnet());
             }
         }
     }
@@ -582,7 +609,7 @@ mod tests {
                 let dai_balance = dai::Amount::from_atto(dai_balance);
                 let dai_reserved_funds = dai::Amount::from_atto(dai_reserved_funds);
 
-                let _: anyhow::Result<BtcDaiOrder> = BtcDaiOrder::new_buy(dai_balance, dai_reserved_funds, None, rate, spread, DaiContractAddress::Mainnet,);
+                let _: anyhow::Result<BtcDaiOrder> = BtcDaiOrder::new_buy(dai_balance, dai_reserved_funds, None, rate, spread, DaiContractAddress::Mainnet, ethereum::ChainId::mainnet());
             }
         }
     }
@@ -599,7 +626,7 @@ mod tests {
             let spread = Spread::new(spread);
 
             if let (Ok(rate), Ok(spread)) = (rate, spread) {
-                let _: anyhow::Result<BtcDaiOrder> = BtcDaiOrder::new_sell(btc_balance, btc_fees, btc_reserved_funds, Some(btc_max_amount), rate, spread, DaiContractAddress::Mainnet,);
+                let _: anyhow::Result<BtcDaiOrder> = BtcDaiOrder::new_sell(btc_balance, btc_fees, btc_reserved_funds, Some(btc_max_amount), rate, spread, DaiContractAddress::Mainnet, ethereum::ChainId::mainnet());
             }
         }
     }
@@ -615,7 +642,7 @@ mod tests {
             let spread = Spread::new(spread);
 
             if let (Ok(rate), Ok(spread)) = (rate, spread) {
-                let _: anyhow::Result<BtcDaiOrder> = BtcDaiOrder::new_sell(btc_balance, btc_fees, btc_reserved_funds, None, rate, spread, DaiContractAddress::Mainnet);
+                let _: anyhow::Result<BtcDaiOrder> = BtcDaiOrder::new_sell(btc_balance, btc_fees, btc_reserved_funds, None, rate, spread, DaiContractAddress::Mainnet, ethereum::ChainId::mainnet());
             }
         }
     }

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -82,7 +82,7 @@ impl TryFrom<BtcDaiOrder> for Rate {
         let (quotient, _) = quote
             .amount
             .as_atto()
-            .div_rem(&BigUint::from(base.as_sat()));
+            .div_rem(&BigUint::from(base.amount.as_sat()));
 
         let rate = divide_pow_ten_trunc(quotient, Self::FROM_ORDER_INV_EXP);
         let rate = rate

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -19,125 +19,6 @@ pub use alice::WatchOnlyAlice;
 pub use bob::WalletBob;
 pub use db::{Database, Save};
 
-// TODO: This is awkward to manipulate
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum SwapKind {
-    HbitHerc20(SwapParams),
-    Herc20Hbit(SwapParams),
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct SwapParams {
-    pub hbit_params: hbit::Params,
-    pub herc20_params: herc20::Params,
-    pub secret_hash: comit::SecretHash,
-    // TODO: Why naive and not DateTime<Local>?
-    pub start_of_swap: chrono::NaiveDateTime,
-    pub swap_id: SwapId,
-    pub taker: Taker,
-}
-
-#[cfg(test)]
-impl Default for SwapParams {
-    fn default() -> Self {
-        use crate::swap::hbit::SecretHash;
-        use ::bitcoin::secp256k1;
-        use std::str::FromStr;
-
-        let secret_hash = SecretHash::new(Secret::from(*b"hello world, you are beautiful!!"));
-
-        SwapParams {
-            hbit_params: hbit::Params {
-                shared: comit::hbit::Params {
-                    network: ::bitcoin::Network::Regtest,
-                    asset: comit::asset::Bitcoin::from_sat(12_345_678),
-                    redeem_identity: comit::bitcoin::PublicKey::from_str(
-                        "039b6347398505f5ec93826dc61c19f47c66c0283ee9be980e29ce325a0f4679ef",
-                    )
-                    .unwrap(),
-                    refund_identity: comit::bitcoin::PublicKey::from_str(
-                        "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af",
-                    )
-                    .unwrap(),
-                    expiry: 12345678u32.into(),
-                    secret_hash,
-                },
-                transient_sk: secp256k1::SecretKey::from_str(
-                    "01010101010101010001020304050607ffff0000ffff00006363636363636363",
-                )
-                .unwrap(),
-            },
-            herc20_params: herc20::Params {
-                asset: comit::asset::Erc20 {
-                    token_contract: Default::default(),
-                    quantity: comit::asset::Erc20Quantity::from_wei_dec_str(
-                        "4_000_000_000_000_000_000",
-                    )
-                    .unwrap(),
-                },
-                redeem_identity: Default::default(),
-                refund_identity: Default::default(),
-                expiry: 987654321.into(),
-                secret_hash,
-                chain_id: 42.into(),
-            },
-            secret_hash: SecretHash::new(Secret::from(*b"hello world, you are beautiful!!")),
-            start_of_swap: chrono::Local::now().naive_local(),
-            swap_id: Default::default(),
-            taker: Taker::default(),
-        }
-    }
-}
-
-pub async fn nectar_hbit_herc20(
-    db: Arc<Database>,
-    bitcoin_wallet: Arc<crate::bitcoin::Wallet>,
-    ethereum_wallet: Arc<crate::ethereum::Wallet>,
-    bitcoin_connector: Arc<comit::btsieve::bitcoin::BitcoindConnector>,
-    ethereum_connector: Arc<comit::btsieve::ethereum::Web3Connector>,
-    SwapParams {
-        hbit_params,
-        herc20_params,
-        secret_hash,
-        start_of_swap,
-        swap_id,
-        ..
-    }: SwapParams,
-) -> anyhow::Result<()> {
-    let alice = WatchOnlyAlice {
-        alpha_connector: Arc::clone(&bitcoin_connector),
-        beta_connector: Arc::clone(&ethereum_connector),
-        db: Arc::clone(&db),
-        alpha_params: hbit_params.shared,
-        beta_params: herc20_params.clone(),
-        secret_hash,
-        start_of_swap,
-        swap_id,
-    };
-
-    let bitcoin_wallet = bitcoin::Wallet {
-        inner: bitcoin_wallet,
-        connector: Arc::clone(&bitcoin_connector),
-    };
-    let ethereum_wallet = ethereum::Wallet {
-        inner: ethereum_wallet,
-        connector: Arc::clone(&ethereum_connector),
-    };
-
-    let bob = WalletBob {
-        alpha_wallet: bitcoin_wallet,
-        beta_wallet: ethereum_wallet,
-        db,
-        alpha_params: hbit_params,
-        beta_params: herc20_params,
-        secret_hash,
-        start_of_swap,
-        swap_id,
-    };
-
-    hbit_herc20(alice, bob).await
-}
-
 /// Execute a Hbit<->Herc20 swap.
 pub async fn hbit_herc20<A, B>(alice: A, bob: B) -> anyhow::Result<()>
 where
@@ -285,6 +166,170 @@ where
     }
 }
 
+// TODO: This is awkward to manipulate
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SwapKind {
+    HbitHerc20(SwapParams),
+    Herc20Hbit(SwapParams),
+}
+
+impl SwapKind {
+    pub fn params(&self) -> SwapParams {
+        match self {
+            SwapKind::HbitHerc20(params) | SwapKind::Herc20Hbit(params) => params.clone(),
+        }
+    }
+
+    pub async fn execute(
+        &self,
+        db: Arc<Database>,
+        bitcoin_wallet: Arc<crate::bitcoin::Wallet>,
+        ethereum_wallet: Arc<crate::ethereum::Wallet>,
+        bitcoin_connector: Arc<comit::btsieve::bitcoin::BitcoindConnector>,
+        ethereum_connector: Arc<comit::btsieve::ethereum::Web3Connector>,
+    ) -> anyhow::Result<()> {
+        let bitcoin_wallet = bitcoin::Wallet {
+            inner: bitcoin_wallet,
+            connector: Arc::clone(&bitcoin_connector),
+        };
+        let ethereum_wallet = ethereum::Wallet {
+            inner: ethereum_wallet,
+            connector: Arc::clone(&ethereum_connector),
+        };
+
+        match self {
+            SwapKind::HbitHerc20(SwapParams {
+                hbit_params,
+                herc20_params,
+                secret_hash,
+                start_of_swap,
+                swap_id,
+                ..
+            }) => {
+                let alice = WatchOnlyAlice {
+                    alpha_connector: Arc::clone(&bitcoin_connector),
+                    beta_connector: Arc::clone(&ethereum_connector),
+                    db: Arc::clone(&db),
+                    alpha_params: hbit_params.shared,
+                    beta_params: herc20_params.clone(),
+                    secret_hash: *secret_hash,
+                    start_of_swap: *start_of_swap,
+                    swap_id: *swap_id,
+                };
+
+                let bob = WalletBob {
+                    alpha_wallet: bitcoin_wallet,
+                    beta_wallet: ethereum_wallet,
+                    db,
+                    alpha_params: *hbit_params,
+                    beta_params: herc20_params.clone(),
+                    secret_hash: *secret_hash,
+                    start_of_swap: *start_of_swap,
+                    swap_id: *swap_id,
+                };
+
+                hbit_herc20(alice, bob).await?
+            }
+            SwapKind::Herc20Hbit(SwapParams {
+                hbit_params,
+                herc20_params,
+                secret_hash,
+                start_of_swap,
+                swap_id,
+                ..
+            }) => {
+                let alice = WatchOnlyAlice {
+                    alpha_connector: Arc::clone(&ethereum_connector),
+                    beta_connector: Arc::clone(&bitcoin_connector),
+                    db: Arc::clone(&db),
+                    alpha_params: herc20_params.clone(),
+                    beta_params: hbit_params.shared,
+                    secret_hash: *secret_hash,
+                    start_of_swap: *start_of_swap,
+                    swap_id: *swap_id,
+                };
+                let bob = WalletBob {
+                    alpha_wallet: ethereum_wallet,
+                    beta_wallet: bitcoin_wallet,
+                    db,
+                    alpha_params: herc20_params.clone(),
+                    beta_params: *hbit_params,
+                    secret_hash: *secret_hash,
+                    start_of_swap: *start_of_swap,
+                    swap_id: *swap_id,
+                };
+
+                herc20_hbit(alice, bob).await?
+            }
+        };
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SwapParams {
+    pub hbit_params: hbit::Params,
+    pub herc20_params: herc20::Params,
+    pub secret_hash: comit::SecretHash,
+    // TODO: Why naive and not DateTime<Local>?
+    pub start_of_swap: chrono::NaiveDateTime,
+    pub swap_id: SwapId,
+    pub taker: Taker,
+}
+
+#[cfg(test)]
+impl Default for SwapParams {
+    fn default() -> Self {
+        use crate::swap::hbit::SecretHash;
+        use ::bitcoin::secp256k1;
+        use std::str::FromStr;
+
+        let secret_hash = SecretHash::new(Secret::from(*b"hello world, you are beautiful!!"));
+
+        SwapParams {
+            hbit_params: hbit::Params {
+                shared: comit::hbit::Params {
+                    network: ::bitcoin::Network::Regtest,
+                    asset: comit::asset::Bitcoin::from_sat(12_345_678),
+                    redeem_identity: comit::bitcoin::PublicKey::from_str(
+                        "039b6347398505f5ec93826dc61c19f47c66c0283ee9be980e29ce325a0f4679ef",
+                    )
+                    .unwrap(),
+                    refund_identity: comit::bitcoin::PublicKey::from_str(
+                        "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af",
+                    )
+                    .unwrap(),
+                    expiry: 12345678u32.into(),
+                    secret_hash,
+                },
+                transient_sk: secp256k1::SecretKey::from_str(
+                    "01010101010101010001020304050607ffff0000ffff00006363636363636363",
+                )
+                .unwrap(),
+            },
+            herc20_params: herc20::Params {
+                asset: comit::asset::Erc20 {
+                    token_contract: Default::default(),
+                    quantity: comit::asset::Erc20Quantity::from_wei_dec_str(
+                        "4_000_000_000_000_000_000",
+                    )
+                    .unwrap(),
+                },
+                redeem_identity: Default::default(),
+                refund_identity: Default::default(),
+                expiry: 987654321.into(),
+                secret_hash,
+                chain_id: 42.into(),
+            },
+            secret_hash: SecretHash::new(Secret::from(*b"hello world, you are beautiful!!")),
+            start_of_swap: chrono::Local::now().naive_local(),
+            swap_id: Default::default(),
+            taker: Taker::default(),
+        }
+    }
+}
+
 #[cfg(all(test, feature = "test-docker"))]
 mod tests {
     use super::*;
@@ -352,7 +397,6 @@ mod tests {
         Secret::from(*bytes)
     }
 
-    // TODO: Implement these traits on a real database
     #[derive(Clone, Copy)]
     struct Database;
 

--- a/src/swap/alice.rs
+++ b/src/swap/alice.rs
@@ -191,6 +191,13 @@ impl<AC, BC, DB, AP> BetaExpiry for WatchOnlyAlice<AC, BC, DB, AP, herc20::Param
 }
 
 #[async_trait::async_trait]
+impl<AC, BC, DB, AP> BetaExpiry for WatchOnlyAlice<AC, BC, DB, AP, hbit::SharedParams> {
+    fn beta_expiry(&self) -> Timestamp {
+        self.beta_params.expiry
+    }
+}
+
+#[async_trait::async_trait]
 impl<AC, BC, DB, AP, BP> BetaLedgerTime for WatchOnlyAlice<AC, BC, DB, AP, BP>
 where
     AC: Send + Sync,

--- a/src/swap/bob.rs
+++ b/src/swap/bob.rs
@@ -161,6 +161,12 @@ impl<AW, BW, DB, AP> BetaExpiry for WalletBob<AW, BW, DB, AP, herc20::Params> {
     }
 }
 
+impl<AW, BW, DB, AP> BetaExpiry for WalletBob<AW, BW, DB, AP, hbit::Params> {
+    fn beta_expiry(&self) -> Timestamp {
+        self.beta_params.shared.expiry
+    }
+}
+
 #[async_trait::async_trait]
 impl<AW, BW, DB, AP, BP> BetaLedgerTime for WalletBob<AW, BW, DB, AP, BP>
 where

--- a/src/swap/ethereum.rs
+++ b/src/swap/ethereum.rs
@@ -1,6 +1,9 @@
 use crate::swap::{herc20, BetaLedgerTime};
 use chrono::NaiveDateTime;
-use comit::{btsieve::LatestBlock, Timestamp};
+use comit::{
+    btsieve::{ethereum::Web3Connector, LatestBlock},
+    Timestamp,
+};
 use std::{sync::Arc, time::Duration};
 
 pub use comit::{
@@ -100,12 +103,16 @@ impl herc20::ExecuteRefund for Wallet {
 }
 
 #[async_trait::async_trait]
-impl<C> BetaLedgerTime for C
-where
-    C: LatestBlock<Block = Block>,
-{
+impl BetaLedgerTime for Web3Connector {
     async fn beta_ledger_time(&self) -> anyhow::Result<Timestamp> {
         ethereum_latest_time(self).await
+    }
+}
+
+#[async_trait::async_trait]
+impl BetaLedgerTime for Wallet {
+    async fn beta_ledger_time(&self) -> anyhow::Result<Timestamp> {
+        self.connector.as_ref().beta_ledger_time().await
     }
 }
 


### PR DESCRIPTION
This allows us to support both buy and sell orders!

It also allows us to set expiries properly when creating orders.

We add missing implementations to enable calling `nectar_herc20_hbit`.

The main limitation now is that orders are still limited to a local development network. This should be easy to fix once we include the network as part of the `dai::Asset` and a possible `nectar::bitcoin::Asset`.