### PR TITLE
Invert the rate

### DIFF
--- a/src/maker.rs
+++ b/src/maker.rs
@@ -730,4 +730,19 @@ mod tests {
         assert_eq!(result, TakeRequestDecision::GoForSwap);
         assert_eq!(maker.dai_reserved_funds, dai_amount(1.0))
     }
+
+    #[test]
+    fn new_buy_order_is_correct() {
+        let maker = Maker {
+            dai_balance: some_dai(20.0),
+            dai_max_sell_amount: some_dai(18.0),
+            mid_market_rate: some_rate(9000.0),
+            btc_balance: some_btc(1.0),
+            ..Default::default()
+        };
+
+        let new_buy_order = maker.new_buy_order().unwrap();
+        assert_eq!(new_buy_order.base.amount, btc(0.002));
+        assert_eq!(new_buy_order.quote.amount, dai_amount(18.0));
+    }
 }

--- a/src/order.rs
+++ b/src/order.rs
@@ -410,9 +410,7 @@ mod tests {
         )
         .unwrap();
 
-        // 1 Sell => 0.1 Buy
-        // 1000 Sell => 100 Buy
-        assert_eq!(order.base, btc_asset(100.0));
+        assert_eq!(order.base, btc_asset(10_000.0));
         assert_eq!(order.quote, dai_asset(1000.0));
 
         let rate = Rate::try_from(10.0).unwrap();
@@ -428,19 +426,19 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(order.base, btc_asset(10_000.0));
+        assert_eq!(order.base, btc_asset(100.0));
         assert_eq!(order.quote, dai_asset(1000.0));
     }
 
     #[test]
     fn given_a_rate_and_spread_return_order_with_both_amounts() {
-        let rate = Rate::try_from(0.1).unwrap();
+        let rate = Rate::try_from(10_000.0).unwrap();
         let spread = Spread::new(300).unwrap();
 
         let order = BtcDaiOrder::new_sell(
-            btc(1051.0),
-            btc(1.0),
-            btc(50.0),
+            btc(1.51),
+            btc(0.01),
+            btc(0.5),
             None,
             rate,
             spread,
@@ -450,11 +448,11 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(order.base, btc_asset(1000.0));
-        assert_eq!(order.quote, dai_asset(103.0));
+        assert_eq!(order.base, btc_asset(1.0));
+        assert_eq!(order.quote, dai_asset(10_300.0));
 
         let order = BtcDaiOrder::new_buy(
-            dai_amount(1051.0),
+            dai_amount(10_051.0),
             dai_amount(51.0),
             None,
             rate,
@@ -465,8 +463,8 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(order.base, btc_asset(97.0));
-        assert_eq!(order.quote, dai_asset(1000.0));
+        assert_eq!(order.base, btc_asset(1.03092783));
+        assert_eq!(order.quote, dai_asset(10_000.0));
     }
 
     #[test]


### PR DESCRIPTION
The rate is always the same, no matter the position so when we want
to convert from quote to base (dai to btc) we needed to divide by the
rate, not multiply.