### PR TITLE
Print newly created orders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.cargo/bin
-          key: ubuntu-rust-${{ env.RUST_TOOLCHAIN }}-cargo-bin-directory-v1
+          key: ubuntu-rust-${{ env.RUST_TOOLCHAIN }}-cargo-bin-directory-v2
 
       - name: Install tomlfmt
         run: which cargo-tomlfmt || cargo install cargo-tomlfmt
@@ -59,13 +59,13 @@ jobs:
         uses: actions/cache@v1
         with:
           path: target
-          key: ${{ matrix.os }}-rust-${{ env.RUST_TOOLCHAIN }}-target-directory-${{ hashFiles('Cargo.lock') }}-v4
+          key: ${{ matrix.os }}-rust-${{ env.RUST_TOOLCHAIN }}-target-directory-${{ hashFiles('Cargo.lock') }}-v5
 
       - name: Cache ~/.cargo/registry directory
         uses: actions/cache@v1
         with:
           path: ~/.cargo/registry
-          key: ${{ matrix.os }}-rust-${{ env.RUST_TOOLCHAIN }}-cargo-registry-directory-${{ hashFiles('Cargo.lock') }}-v4
+          key: ${{ matrix.os }}-rust-${{ env.RUST_TOOLCHAIN }}-cargo-registry-directory-${{ hashFiles('Cargo.lock') }}-v5
 
       - name: Cargo check ${{ matrix.os }}
         run: cargo check

--- a/src/maker.rs
+++ b/src/maker.rs
@@ -130,22 +130,17 @@ impl Maker {
 
     pub fn new_sell_order(&self) -> anyhow::Result<BtcDaiOrder> {
         match (self.mid_market_rate, self.btc_balance) {
-            (Some(mid_market_rate), Some(btc_balance)) => {
-                let order = BtcDaiOrder::new_sell(
-                    btc_balance,
-                    self.btc_fee,
-                    self.btc_reserved_funds,
-                    self.btc_max_sell_amount,
-                    mid_market_rate.into(),
-                    self.spread,
-                    self.dai_contract_address,
-                    self.bitcoin_network,
-                    self.ethereum_network,
-                )?;
-
-                tracing::info!("New order created: {}", order);
-                Ok(order)
-            }
+            (Some(mid_market_rate), Some(btc_balance)) => BtcDaiOrder::new_sell(
+                btc_balance,
+                self.btc_fee,
+                self.btc_reserved_funds,
+                self.btc_max_sell_amount,
+                mid_market_rate.into(),
+                self.spread,
+                self.dai_contract_address,
+                self.bitcoin_network,
+                self.ethereum_network,
+            ),
             (None, _) => anyhow::bail!(RateNotAvailable(Position::Sell)),
             (_, None) => anyhow::bail!(BalanceNotAvailable(Symbol::Btc)),
         }
@@ -153,21 +148,16 @@ impl Maker {
 
     pub fn new_buy_order(&self) -> anyhow::Result<BtcDaiOrder> {
         match (self.mid_market_rate, self.dai_balance.clone()) {
-            (Some(mid_market_rate), Some(dai_balance)) => {
-                let order = BtcDaiOrder::new_buy(
-                    dai_balance,
-                    self.dai_reserved_funds.clone(),
-                    self.dai_max_sell_amount.clone(),
-                    mid_market_rate.into(),
-                    self.spread,
-                    self.dai_contract_address,
-                    self.bitcoin_network,
-                    self.ethereum_network,
-                )?;
-
-                tracing::info!("New order created: {}", order);
-                Ok(order)
-            }
+            (Some(mid_market_rate), Some(dai_balance)) => BtcDaiOrder::new_buy(
+                dai_balance,
+                self.dai_reserved_funds.clone(),
+                self.dai_max_sell_amount.clone(),
+                mid_market_rate.into(),
+                self.spread,
+                self.dai_contract_address,
+                self.bitcoin_network,
+                self.ethereum_network,
+            ),
             (None, _) => anyhow::bail!(RateNotAvailable(Position::Buy)),
             (_, None) => anyhow::bail!(BalanceNotAvailable(Symbol::Dai)),
         }

--- a/src/maker.rs
+++ b/src/maker.rs
@@ -130,17 +130,22 @@ impl Maker {
 
     pub fn new_sell_order(&self) -> anyhow::Result<BtcDaiOrder> {
         match (self.mid_market_rate, self.btc_balance) {
-            (Some(mid_market_rate), Some(btc_balance)) => BtcDaiOrder::new_sell(
-                btc_balance,
-                self.btc_fee,
-                self.btc_reserved_funds,
-                self.btc_max_sell_amount,
-                mid_market_rate.into(),
-                self.spread,
-                self.dai_contract_address,
-                self.bitcoin_network,
-                self.ethereum_network,
-            ),
+            (Some(mid_market_rate), Some(btc_balance)) => {
+                let order = BtcDaiOrder::new_sell(
+                    btc_balance,
+                    self.btc_fee,
+                    self.btc_reserved_funds,
+                    self.btc_max_sell_amount,
+                    mid_market_rate.into(),
+                    self.spread,
+                    self.dai_contract_address,
+                    self.bitcoin_network,
+                    self.ethereum_network,
+                )?;
+
+                tracing::info!("New order created: {}", order);
+                Ok(order)
+            }
             (None, _) => anyhow::bail!(RateNotAvailable(Position::Sell)),
             (_, None) => anyhow::bail!(BalanceNotAvailable(Symbol::Btc)),
         }
@@ -148,16 +153,21 @@ impl Maker {
 
     pub fn new_buy_order(&self) -> anyhow::Result<BtcDaiOrder> {
         match (self.mid_market_rate, self.dai_balance.clone()) {
-            (Some(mid_market_rate), Some(dai_balance)) => BtcDaiOrder::new_buy(
-                dai_balance,
-                self.dai_reserved_funds.clone(),
-                self.dai_max_sell_amount.clone(),
-                mid_market_rate.into(),
-                self.spread,
-                self.dai_contract_address,
-                self.bitcoin_network,
-                self.ethereum_network,
-            ),
+            (Some(mid_market_rate), Some(dai_balance)) => {
+                let order = BtcDaiOrder::new_buy(
+                    dai_balance,
+                    self.dai_reserved_funds.clone(),
+                    self.dai_max_sell_amount.clone(),
+                    mid_market_rate.into(),
+                    self.spread,
+                    self.dai_contract_address,
+                    self.bitcoin_network,
+                    self.ethereum_network,
+                )?;
+
+                tracing::info!("New order created: {}", order);
+                Ok(order)
+            }
             (None, _) => anyhow::bail!(RateNotAvailable(Position::Buy)),
             (_, None) => anyhow::bail!(BalanceNotAvailable(Symbol::Dai)),
         }

--- a/src/network.rs
+++ b/src/network.rs
@@ -86,6 +86,7 @@ impl Swarm {
     }
 
     pub fn publish(&mut self, order: PublishOrder) -> anyhow::Result<()> {
+        tracing::info!("Publishing new order: {}", order.0);
         self.inner.make(order)
     }
 

--- a/src/order.rs
+++ b/src/order.rs
@@ -6,7 +6,8 @@ use crate::{
     },
     MidMarketRate, Rate, Spread,
 };
-use std::{cmp::min, convert::TryFrom};
+use std::fmt::{Display, Formatter};
+use std::{cmp::min, convert::TryFrom, fmt};
 
 #[derive(Debug, Copy, Clone, strum_macros::Display)]
 #[strum(serialize_all = "UPPERCASE")]
@@ -142,6 +143,19 @@ impl BtcDaiOrder {
                 Ok(order_rate >= mid_market_rate.into())
             }
         }
+    }
+}
+
+impl Display for BtcDaiOrder {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}, {}, {}",
+            self.position,
+            self.base.amount.to_string(),
+            self.quote.amount.to_string()
+        )?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Minimal printing of the order position and nominal values.

I think this is actually so basic that it is fine to add. We can also drop it, but I feel a bit more context would be good when running `trade`. (I also thought about printing the `Rate` and `Balance` but did not go there yet...)

```
Jul 22 15:50:15.919  INFO nectar::trace: Initialized tracing with level: INFO
Jul 22 15:50:15.923  INFO nectar::config::seed: Read in seed from file: /Users/dakami/Library/Application Support/nectar/seed.pem
Jul 22 15:50:16.471  INFO libp2p_gossipsub::behaviour: Subscribed to topic: BTC/DAI    
Jul 22 15:50:16.472  INFO nectar::maker: New order created: Position: Sell, BTC: 0.09990725, DAI: 967.83
Jul 22 15:50:16.472  INFO nectar::maker: New order created: Position: Buy, BTC: 175294, DAI: 20
Jul 22 15:50:16.473  INFO libp2p_gossipsub::behaviour: Published message: MessageId("2276897037252766832")    
Jul 22 15:50:16.473  INFO libp2p_gossipsub::behaviour: Published message: MessageId("13304717341951990730")  
```

Note that the `Buy` order's BTC amount is already fixed, here https://github.com/coblox/nectar/pull/76#pullrequestreview-453010128