### PR TITLE
More resilient `wallet-info`

### DIFF
--- a/src/command/wallet_info.rs
+++ b/src/command/wallet_info.rs
@@ -1,11 +1,13 @@
-use crate::{bitcoin, ethereum};
+use crate::{bitcoin, ethereum, Seed};
 
 pub async fn wallet_info(
-    ethereum_wallet: ethereum::Wallet,
-    bitcoin_wallet: bitcoin::Wallet,
+    ethereum_wallet: Option<ethereum::Wallet>,
+    bitcoin_wallet: Option<bitcoin::Wallet>,
+    seed: &Seed,
+    bitcoin_network: bitcoin::Network,
 ) -> anyhow::Result<String> {
-    let bitcoin_info = bitcoin_info(bitcoin_wallet).await?;
-    let ethereum_info = ethereum_info(ethereum_wallet);
+    let bitcoin_info = bitcoin_info(bitcoin_wallet, &seed, bitcoin_network).await;
+    let ethereum_info = ethereum_info(ethereum_wallet, &seed);
 
     Ok(format!(
         "Bitcoin wallet descriptors:\n{}\nEthereum private key:\n{}",
@@ -13,13 +15,32 @@ pub async fn wallet_info(
     ))
 }
 
-async fn bitcoin_info(bitcoin_wallet: bitcoin::Wallet) -> anyhow::Result<String> {
-    let descriptors = bitcoin_wallet.descriptors_with_checksums().await?;
-    Ok(descriptors.join("\n"))
+async fn bitcoin_info(
+    bitcoin_wallet: Option<bitcoin::Wallet>,
+    seed: &Seed,
+    network: bitcoin::Network,
+) -> String {
+    let descriptors = match bitcoin_wallet {
+        Some(bitcoin_wallet) => bitcoin_wallet.descriptors_with_checksums().await.ok(),
+        None => None,
+    };
+
+    match descriptors {
+        Some(descriptors) => descriptors.join("\n"),
+        None => {
+            let descriptors = bitcoin::Wallet::descriptors_from_seed(&seed, network);
+            format!("(could not reach bitcoind)\n{}", descriptors.join("\n"))
+        }
+    }
 }
 
-fn ethereum_info(ethereum_wallet: ethereum::Wallet) -> String {
-    ethereum_wallet.private_key().to_string()
+fn ethereum_info(ethereum_wallet: Option<ethereum::Wallet>, seed: &Seed) -> String {
+    match ethereum_wallet {
+        Some(ethereum_wallet) => ethereum_wallet.private_key().to_string(),
+        None => ethereum::Wallet::private_key_from_seed(seed)
+            .expect("Derive private key from seed")
+            .to_string(),
+    }
 }
 
 #[cfg(all(test, feature = "test-docker"))]
@@ -56,7 +77,24 @@ mod tests {
         )
         .await?;
 
-        let stdout = wallet_info(ethereum_wallet, bitcoin_wallet).await?;
+        let stdout = wallet_info(
+            Some(ethereum_wallet),
+            Some(bitcoin_wallet),
+            &seed,
+            bitcoin::Network::Regtest,
+        )
+        .await?;
+        println!("{}", stdout);
+        Ok(())
+    }
+
+    // Run cargo test with `--ignored --nocapture` to see the `println output`
+    #[ignore]
+    #[tokio::test]
+    async fn wallet_info_command_no_nodes() -> anyhow::Result<()> {
+        let seed = Seed::random().unwrap();
+
+        let stdout = wallet_info(None, None, &seed, bitcoin::Network::Regtest).await?;
         println!("{}", stdout);
         Ok(())
     }

--- a/src/ethereum/wallet.rs
+++ b/src/ethereum/wallet.rs
@@ -31,8 +31,7 @@ impl Wallet {
         dai_contract_addr: Address,
         chain_id: ChainId,
     ) -> anyhow::Result<Self> {
-        let private_key = clarity::PrivateKey::from_slice(&seed.bytes())
-            .map_err(|_| anyhow::anyhow!("Failed to derive private key from slice"))?;
+        let private_key = Wallet::private_key_from_seed(&seed)?;
 
         let geth_client = Client::new(url);
 
@@ -46,6 +45,12 @@ impl Wallet {
         wallet.assert_chain(chain_id).await?;
 
         Ok(wallet)
+    }
+
+    pub fn private_key_from_seed(seed: &Seed) -> anyhow::Result<clarity::PrivateKey> {
+        let private_key = clarity::PrivateKey::from_slice(&seed.bytes())
+            .map_err(|_| anyhow::anyhow!("Failed to derive private key from slice"))?;
+        Ok(private_key)
     }
 
     #[cfg(test)]


### PR DESCRIPTION
Allow `nectar wallet-info` to print even if no blockchain nodes are reachable.