### PR TITLE
Upgrade comit-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,7 @@ dependencies = [
 [[package]]
 name = "comit"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/comit-rs?rev=35aeb97525ebca153c5f8483c0aa2952c8e16d39#35aeb97525ebca153c5f8483c0aa2952c8e16d39"
+source = "git+https://github.com/comit-network/comit-rs?rev=3605d8710cc4b03d5145f595d45786da93b85324#3605d8710cc4b03d5145f595d45786da93b85324"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -803,7 +803,7 @@ dependencies = [
 [[package]]
 name = "digest"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/comit-rs?rev=35aeb97525ebca153c5f8483c0aa2952c8e16d39#35aeb97525ebca153c5f8483c0aa2952c8e16d39"
+source = "git+https://github.com/comit-network/comit-rs?rev=3605d8710cc4b03d5145f595d45786da93b85324#3605d8710cc4b03d5145f595d45786da93b85324"
 dependencies = [
  "digest-macro-derive",
  "hex 0.4.2",
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "digest-macro-derive"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/comit-rs?rev=35aeb97525ebca153c5f8483c0aa2952c8e16d39#35aeb97525ebca153c5f8483c0aa2952c8e16d39"
+source = "git+https://github.com/comit-network/comit-rs?rev=3605d8710cc4b03d5145f595d45786da93b85324#3605d8710cc4b03d5145f595d45786da93b85324"
 dependencies = [
  "hex 0.4.2",
  "proc-macro2 1.0.19",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ bimap = "0.4"
 bitcoin = { version = "0.23.0", features = ["rand", "use-serde"] }
 chrono = "0.4"
 clarity = "0.1"
-comit = { git = "https://github.com/comit-network/comit-rs", package = "comit", rev = "35aeb97525ebca153c5f8483c0aa2952c8e16d39" }
+comit = { git = "https://github.com/comit-network/comit-rs", package = "comit", rev = "3605d8710cc4b03d5145f595d45786da93b85324" }
 config = "0.10"
 conquer-once = "0.2"
 csv = "1.1"


### PR DESCRIPTION
Hoping to fix the `can't find crate for `serde_derive` which `bitcoin`
depends on` error thanks to comit-network/comit-rs#b1315f28a4073b6aaf35a55bcb13109c2f8f0264