### PR TITLE
Improve config documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # nectar
+
+`nectar help` to see the available commands.
+
+Check `./sample-config.toml` if you want to customize the config.

--- a/sample-config.toml
+++ b/sample-config.toml
@@ -1,10 +1,9 @@
-# `nectar.toml` Configuration File
+# Nectar Configuration File
 
-The configuration file must be in TOML format.
-The current config can be printed using `nectar dump-config`.
-A custom location to the config file can be specified using `--config`.
+# The configuration file must be in TOML format.
+# The current config can be printed using `nectar dump-config`.
+# A custom location to the config file can be specified using `--config`.
 
-```toml
 [maker]
 # The spread to apply to the mid-market when publish an offer. It's a pyrimiad format, 12.34 = 12.34% spread.
 spread = 500
@@ -47,4 +46,3 @@ node_url = "http://localhost:18443/"
 chain_id = 1
 # The url to the web3 node, can include an infura key: `https://mainnet.infura.io/v3/YOUR-PROJECT-ID`
 node_url = "http://localhost:8545/"
-```

--- a/src/command.rs
+++ b/src/command.rs
@@ -35,11 +35,17 @@ impl Options {
 
 #[derive(StructOpt, Debug, Clone)]
 pub enum Command {
+    /// Start to publish order and execute them
     Trade,
+    /// Print all wallets information for backup or export purposes
     WalletInfo,
+    /// Print the actual balance on all assets
     Balance,
+    /// Print wallet addresses to deposit assets
     Deposit,
+    /// Dump the current configuration
     DumpConfig,
+    /// Withdraw assets
     Withdraw(Withdraw),
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,7 @@ pub fn read_config(config_file: &Option<PathBuf>) -> anyhow::Result<File> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{bitcoin, config::file::Level, ethereum::ChainId, Spread};
 
     #[test]
     fn network_deserializes_correctly() {
@@ -104,5 +105,47 @@ mod tests {
             .unwrap();
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn sample_config_deserializes_correctly() {
+        let expected = File {
+            maker: Some(file::Maker {
+                max_sell: Some(MaxSell {
+                    bitcoin: Some(bitcoin::Amount::from_btc(0.1).unwrap()),
+                    dai: Some(dai::Amount::from_dai_trunc(1000.0).unwrap()),
+                }),
+                spread: Some(Spread::new(500).unwrap()),
+                maximum_possible_fee: Some(file::Fees {
+                    bitcoin: Some(bitcoin::Amount::from_btc(0.00009275).unwrap()),
+                }),
+            }),
+            network: Some(Network {
+                listen: vec!["/ip4/0.0.0.0/tcp/9939".parse().unwrap()],
+            }),
+            data: Some(Data {
+                dir: "/Users/froyer/Library/Application Support/nectar"
+                    .parse()
+                    .unwrap(),
+            }),
+            logging: Some(file::Logging {
+                level: Some(Level::Info),
+            }),
+            bitcoin: Some(file::Bitcoin {
+                network: bitcoin::Network::Regtest,
+                bitcoind: Some(Bitcoind {
+                    node_url: "http://localhost:18443/".parse().unwrap(),
+                }),
+            }),
+            ethereum: Some(file::Ethereum {
+                chain_id: ChainId::mainnet(),
+                node_url: Some("http://localhost:8545/".parse().unwrap()),
+                local_dai_contract_address: None,
+            }),
+        };
+
+        let config = read_config(&Some(PathBuf::from("sample-config.toml"))).unwrap();
+
+        assert_eq!(config, expected);
     }
 }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -142,7 +142,7 @@ mod tests {
     use crate::config::{Bitcoind, Settings};
     use crate::{bitcoin, ethereum::dai};
     use spectral::prelude::*;
-    use std::io::{BufRead, BufReader, Write};
+    use std::io::Write;
     use std::path::PathBuf;
     use tempdir::TempDir;
 
@@ -483,30 +483,5 @@ local_dai_contract_address = "0x6a9865ade2b6207daac49f8bcba9705deb0b0e6d"
             .unwrap();
 
         assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn sample_config_deserializes_correctly() {
-        let file = std::fs::File::open("nectar-toml.md").unwrap();
-        let file = BufReader::new(file);
-
-        let config_lines: Result<Vec<String>, _> = file
-            .lines()
-            .skip_while(|line| {
-                line.as_ref()
-                    .map(|line| !line.starts_with("[maker]"))
-                    .unwrap_or(true)
-            })
-            .take_while(|line| {
-                line.as_ref()
-                    .map(|line| !line.ends_with("```"))
-                    .unwrap_or(false)
-            })
-            .collect();
-
-        let config = config_lines.unwrap().join("\n");
-
-        let file = toml::from_str::<File>(&config);
-        assert!(file.is_ok());
     }
 }


### PR DESCRIPTION
Use a sample toml config file instead of embedded in markdown.
Parse and check the result as part of the tests.