### PR TITLE
Fix default-config loading bug.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -46,23 +46,25 @@ pub fn read_config(config_file: &Option<PathBuf>) -> anyhow::Result<File> {
             eprintln!("Using config file {}", path.display());
             path
         })
-        .ok_or_else(|| {
-            // try to load default config
-            let default_path = crate::fs::default_config_path()?;
+        .map_or_else(
+            || {
+                // try to load default config
+                let default_path = crate::fs::default_config_path()?;
 
-            if default_path.exists() {
-                eprintln!(
-                    "Using config file at default path: {}",
-                    default_path.display()
-                );
-                Ok(default_path)
-            } else {
-                eprintln!("Config file default path is {}", default_path.display());
-                Err(anyhow!("internal error (unreachable)"))
-            }
-        })
+                if default_path.exists() {
+                    eprintln!(
+                        "Using config file at default path: {}",
+                        default_path.display()
+                    );
+                    Ok(default_path)
+                } else {
+                    eprintln!("Config file default path is {}", default_path.display());
+                    Err(anyhow!("internal error (unreachable)"))
+                }
+            },
+            |path| Ok(path.to_path_buf()),
+        )
         .ok();
-
     match path {
         Some(path) => File::read(&path)
             .with_context(|| format!("failed to read config file {}", path.display())),

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,7 +39,10 @@ pub struct MaxSell {
     pub dai: Option<dai::Amount>,
 }
 
-pub fn read_config(config_file: &Option<PathBuf>) -> anyhow::Result<File> {
+pub fn read_config<T>(config_file: &Option<PathBuf>, default_config_path: T) -> anyhow::Result<File>
+where
+    T: FnOnce() -> anyhow::Result<PathBuf>,
+{
     let path = config_file
         .as_ref()
         .map(|path| {
@@ -49,7 +52,7 @@ pub fn read_config(config_file: &Option<PathBuf>) -> anyhow::Result<File> {
         .map_or_else(
             || {
                 // try to load default config
-                let default_path = crate::fs::default_config_path()?;
+                let default_path = default_config_path()?;
 
                 if default_path.exists() {
                     eprintln!(
@@ -76,6 +79,8 @@ pub fn read_config(config_file: &Option<PathBuf>) -> anyhow::Result<File> {
 mod tests {
     use super::*;
     use crate::{bitcoin, config::file::Level, ethereum::ChainId, Spread};
+    use std::fs;
+    use std::io::Write;
 
     #[test]
     fn network_deserializes_correctly() {
@@ -146,8 +151,59 @@ mod tests {
             }),
         };
 
-        let config = read_config(&Some(PathBuf::from("sample-config.toml"))).unwrap();
+        let config = read_config(
+            &Some(PathBuf::from("sample-config.toml")),
+            || unreachable!(),
+        )
+        .unwrap();
 
         assert_eq!(config, expected);
+    }
+
+    #[test]
+    fn read_config_uses_default_path() {
+        let tmp_dir = tempdir::TempDir::new("nectar_test").unwrap();
+        let default_path = tmp_dir.path().join("config.toml");
+
+        let mut file = fs::File::create(default_path.clone()).unwrap();
+        file.write_all(b"[data]\ndir = \"/not/a/default/location/\"")
+            .unwrap();
+
+        let default_path_fn = || Ok(default_path);
+
+        let config = read_config(&None, default_path_fn).unwrap();
+        assert_eq!(
+            config.data.unwrap().dir,
+            PathBuf::from("/not/a/default/location/")
+        )
+    }
+
+    #[test]
+    fn read_config_returns_default_config_if_default_path_errors() {
+        let default_path_fn = || Err(anyhow!("Some error"));
+
+        let config = read_config(&None, default_path_fn).unwrap();
+        assert_eq!(
+            config,
+            File {
+                maker: None,
+                network: None,
+                data: None,
+                logging: None,
+                bitcoin: None,
+                ethereum: None,
+            },
+        )
+    }
+
+    #[test]
+    fn read_config_errors_if_passed_path_doesnt_exist() {
+        let default_path_fn = || unreachable!();
+
+        let config = read_config(
+            &Some(PathBuf::from("/this/path/doesnt/exist")),
+            default_path_fn,
+        );
+        assert!(config.is_err())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,7 @@ use crate::{
 };
 use conquer_once::Lazy;
 
+use crate::fs::default_config_path;
 pub use maker::Maker;
 pub use mid_market_rate::MidMarketRate;
 pub use rate::{Rate, Spread};
@@ -62,7 +63,7 @@ pub static SECP: Lazy<::bitcoin::secp256k1::Secp256k1<::bitcoin::secp256k1::All>
 async fn main() {
     let options = Options::from_args();
 
-    let settings = read_config(&options.config_file)
+    let settings = read_config(&options.config_file, default_config_path)
         .and_then(Settings::from_config_file_and_defaults)
         .expect("Could not initialize configuration");
 


### PR DESCRIPTION
I found a small bug when loading the config from the default location.

`ok_or_else` was used which essentially mapped to `Result<PathBuf, Error(Result<Path, Error>))`

Which resulted in the following behavior: 
if nectar was started with `-c /default/path/to/config/"` it would return Ok("/default/path/to/config/"). 
However, if the config param was left away, the mapping function would result in `Err(Ok("/default/path/to/config/")). 
At the end you were calling `ok()` on that result which mapped `Err(...)` to `Option::None` and hence always defaulting to the default config. 

Sorry for not providing a test and maybe there is also a neater way to solve this than using `map_or_else` which would get rid of the `to_path` mapping :) 
