### PR TITLE
Database improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,6 +1287,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
+
+[[package]]
 name = "hashbrown"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,6 +2073,7 @@ dependencies = [
  "reqwest",
  "serde 1.0.114",
  "serde-hex",
+ "serde_cbor",
  "serde_json",
  "sled",
  "spectral",
@@ -3334,6 +3341,16 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
+ "serde 1.0.114",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+dependencies = [
+ "half",
  "serde 1.0.114",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,6 +896,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "error"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2051,6 +2061,8 @@ dependencies = [
  "num256",
  "pem",
  "proptest",
+ "quickcheck",
+ "quickcheck_async",
  "rand 0.6.5",
  "reqwest",
  "serde 1.0.114",
@@ -2720,6 +2732,28 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quickcheck"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "quickcheck_async"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "247df671941313a4e255a5015772917368f1b21bfedfbd89d68fbb27e802b2fa"
+dependencies = [
+ "quote 1.0.7",
+ "syn 1.0.36",
+]
 
 [[package]]
 name = "quicksink"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ pem = "0.8"
 reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde-hex = "0.1"
+serde_cbor = "0.11"
 serde_json = "1.0"
 sled = "0.32"
 spectral = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ version = "0.6"
 [dev-dependencies]
 base64 = "0.12"
 proptest = "0.10"
+quickcheck = "0.9"
+quickcheck_async = "0.1"
 tempdir = "0.3"
 testcontainers = "0.9"
 

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -1,0 +1,14 @@
+use comit::{SecretHash, Timestamp};
+use quickcheck::{Arbitrary, Gen};
+
+pub fn secret_hash<G: Gen>(g: &mut G) -> SecretHash {
+    let mut bytes = [0u8; 32];
+    for byte in &mut bytes {
+        *byte = u8::arbitrary(g);
+    }
+    SecretHash::from(bytes)
+}
+
+pub fn timestamp<G: Gen>(g: &mut G) -> Timestamp {
+    Timestamp::from(u32::arbitrary(g))
+}

--- a/src/command/resume_only.rs
+++ b/src/command/resume_only.rs
@@ -80,7 +80,7 @@ async fn execute_swap(
     ethereum_connector: Arc<comit::btsieve::ethereum::Web3Connector>,
     swap: SwapKind,
 ) -> anyhow::Result<FinishedSwap> {
-    db.insert_swap(swap.clone())?;
+    db.insert_swap(swap.clone()).await?;
 
     swap.execute(
         Arc::clone(&db),

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,9 @@ mod trace;
 #[cfg(test)]
 mod test_harness;
 
+#[cfg(test)]
+mod arbitrary;
+
 use crate::{
     command::{
         balance, deposit, dump_config, resume_only, trade, wallet_info, withdraw, Command, Options,

--- a/src/network.rs
+++ b/src/network.rs
@@ -631,3 +631,22 @@ mod transport {
         Ok(transport)
     }
 }
+
+#[cfg(test)]
+mod arbitrary {
+    use super::*;
+    use libp2p::multihash;
+    use quickcheck::{Arbitrary, Gen};
+
+    impl Arbitrary for Taker {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            let mut bytes = [0u8; 32];
+            for byte in bytes.iter_mut() {
+                *byte = u8::arbitrary(g);
+            }
+            let peer_id =
+                PeerId::from_multihash(multihash::wrap(multihash::Code::Sha2_256, &bytes)).unwrap();
+            Taker { peer_id }
+        }
+    }
+}

--- a/src/network.rs
+++ b/src/network.rs
@@ -83,8 +83,8 @@ impl Swarm {
         self.inner.make(order)
     }
 
-    pub fn confirm(&mut self, order: TakenOrder) -> anyhow::Result<()> {
-        self.inner.confirm(order)
+    pub async fn confirm(&mut self, order: TakenOrder) -> anyhow::Result<()> {
+        self.inner.confirm(order).await
     }
 
     pub fn deny(&mut self, order: TakenOrder) {
@@ -187,8 +187,10 @@ impl Nectar {
         Ok(())
     }
 
-    fn confirm(&mut self, order: TakenOrder) -> anyhow::Result<()> {
-        self.database.insert_active_taker(order.taker.clone())?;
+    async fn confirm(&mut self, order: TakenOrder) -> anyhow::Result<()> {
+        self.database
+            .insert_active_taker(order.taker.clone())
+            .await?;
 
         self.orderbook
             .confirm(order.id, order.confirmation_channel, order.taker.peer_id());

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -559,7 +559,7 @@ mod tests {
                 taker: Taker::static_stub(),
             });
 
-            alice_db.insert_swap(swap).unwrap();
+            alice_db.insert_swap(swap).await.unwrap();
 
             let alice = WalletAlice {
                 alpha_wallet: alice_bitcoin_wallet.clone(),
@@ -600,7 +600,7 @@ mod tests {
                 taker: Taker::static_stub(),
             });
 
-            bob_db.insert_swap(swap).unwrap();
+            bob_db.insert_swap(swap).await.unwrap();
 
             let alice = WatchOnlyAlice {
                 alpha_connector: Arc::clone(&bitcoin_connector),

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -333,6 +333,70 @@ impl crate::StaticStub for SwapParams {
     }
 }
 
+#[cfg(test)]
+mod arbitrary {
+    use super::*;
+    use crate::arbitrary::*;
+    use comit::{
+        asset::{ethereum::TryFromWei, Erc20, Erc20Quantity},
+        ethereum::ChainId,
+    };
+    use quickcheck::{Arbitrary, Gen};
+
+    impl Arbitrary for SwapKind {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            if bool::arbitrary(g) {
+                SwapKind::HbitHerc20(SwapParams::arbitrary(g))
+            } else {
+                SwapKind::Herc20Hbit(SwapParams::arbitrary(g))
+            }
+        }
+    }
+
+    impl Arbitrary for SwapParams {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            let herc20_params = herc20::Params {
+                asset: erc20(g),
+                redeem_identity: ethereum_address(g),
+                refund_identity: ethereum_address(g),
+                expiry: timestamp(g),
+                secret_hash: secret_hash(g),
+                chain_id: ChainId::from(u32::arbitrary(g)),
+            };
+
+            SwapParams {
+                hbit_params: hbit::Params::arbitrary(g),
+                herc20_params,
+                secret_hash: secret_hash(g),
+                start_of_swap: chrono::NaiveDateTime::from_timestamp(u32::arbitrary(g) as i64, 0),
+                swap_id: SwapId::arbitrary(g),
+                taker: Taker::arbitrary(g),
+            }
+        }
+    }
+
+    fn ethereum_address<G: Gen>(g: &mut G) -> ethereum::Address {
+        let mut bytes = [0u8; 20];
+        for byte in &mut bytes {
+            *byte = u8::arbitrary(g);
+        }
+        ethereum::Address::from(bytes)
+    }
+
+    fn erc20<G: Gen>(g: &mut G) -> Erc20 {
+        let mut bytes = [0u8; 8];
+        for byte in bytes.iter_mut() {
+            *byte = u8::arbitrary(g);
+        }
+        let int = num::BigUint::from_bytes_be(&bytes);
+        let quantity = Erc20Quantity::try_from_wei(int).unwrap();
+        Erc20 {
+            token_contract: ethereum_address(g),
+            quantity,
+        }
+    }
+}
+
 #[cfg(all(test, feature = "test-docker"))]
 mod tests {
     use super::*;

--- a/src/swap/db.rs
+++ b/src/swap/db.rs
@@ -199,14 +199,14 @@ pub fn serialize<T>(t: &T) -> anyhow::Result<Vec<u8>>
 where
     T: Serialize,
 {
-    Ok(serde_json::to_vec(t)?)
+    Ok(serde_cbor::to_vec(t)?)
 }
 
 pub fn deserialize<'a, T>(v: &'a [u8]) -> anyhow::Result<T>
 where
     T: Deserialize<'a>,
 {
-    Ok(serde_json::from_slice(v)?)
+    Ok(serde_cbor::from_slice(v)?)
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/swap/db/hbit.rs
+++ b/src/swap/db/hbit.rs
@@ -1,6 +1,6 @@
 use crate::{
     swap::{
-        db::{Database, Load, Save},
+        db::{serialize, Database, Load, Save},
         hbit,
     },
     SwapId,
@@ -58,15 +58,14 @@ impl Save<hbit::Funded> for Database {
         match stored_swap.hbit_funded {
             Some(_) => Err(anyhow!("Hbit Funded event is already stored")),
             None => {
-                let key = serde_json::to_vec(&swap_id)?;
+                let key = serialize(&swap_id)?;
 
                 let mut swap = stored_swap.clone();
                 swap.hbit_funded = Some(event.into());
 
-                let old_value = serde_json::to_vec(&stored_swap)
-                    .context("Could not serialize old swap value")?;
-                let new_value =
-                    serde_json::to_vec(&swap).context("Could not serialize new swap value")?;
+                let old_value =
+                    serialize(&stored_swap).context("Could not serialize old swap value")?;
+                let new_value = serialize(&swap).context("Could not serialize new swap value")?;
 
                 self.db
                     .compare_and_swap(key, Some(old_value), Some(new_value))
@@ -123,15 +122,14 @@ impl Save<hbit::Redeemed> for Database {
         match stored_swap.hbit_redeemed {
             Some(_) => Err(anyhow!("Hbit Redeemed event is already stored")),
             None => {
-                let key = serde_json::to_vec(&swap_id)?;
+                let key = serialize(&swap_id)?;
 
                 let mut swap = stored_swap.clone();
                 swap.hbit_redeemed = Some(event.into());
 
-                let old_value = serde_json::to_vec(&stored_swap)
-                    .context("Could not serialize old swap value")?;
-                let new_value =
-                    serde_json::to_vec(&swap).context("Could not serialize new swap value")?;
+                let old_value =
+                    serialize(&stored_swap).context("Could not serialize old swap value")?;
+                let new_value = serialize(&swap).context("Could not serialize new swap value")?;
 
                 self.db
                     .compare_and_swap(key, Some(old_value), Some(new_value))
@@ -184,15 +182,14 @@ impl Save<hbit::Refunded> for Database {
         match stored_swap.hbit_refunded {
             Some(_) => Err(anyhow!("Hbit Refunded event is already stored")),
             None => {
-                let key = serde_json::to_vec(&swap_id)?;
+                let key = serialize(&swap_id)?;
 
                 let mut swap = stored_swap.clone();
                 swap.hbit_refunded = Some(event.into());
 
-                let old_value = serde_json::to_vec(&stored_swap)
-                    .context("Could not serialize old swap value")?;
-                let new_value =
-                    serde_json::to_vec(&swap).context("Could not serialize new swap value")?;
+                let old_value =
+                    serialize(&stored_swap).context("Could not serialize old swap value")?;
+                let new_value = serialize(&swap).context("Could not serialize new swap value")?;
 
                 self.db
                     .compare_and_swap(key, Some(old_value), Some(new_value))

--- a/src/swap/db/hbit.rs
+++ b/src/swap/db/hbit.rs
@@ -331,7 +331,7 @@ mod tests {
 
         let swap_kind = SwapKind::from((swap, swap_id));
 
-        db.insert_swap(swap_kind).unwrap();
+        db.insert_swap(swap_kind).await.unwrap();
 
         let funded = hbit::Funded { asset, location };
         db.save(funded, swap_id).await.unwrap();
@@ -355,7 +355,7 @@ mod tests {
 
         let swap_kind = SwapKind::from((swap, swap_id));
 
-        db.insert_swap(swap_kind).unwrap();
+        db.insert_swap(swap_kind).await.unwrap();
 
         let event = hbit::Redeemed {
             transaction: transaction.clone(),
@@ -381,7 +381,7 @@ mod tests {
 
         let swap_kind = SwapKind::from((swap, swap_id));
 
-        db.insert_swap(swap_kind).unwrap();
+        db.insert_swap(swap_kind).await.unwrap();
 
         let event = hbit::Refunded {
             transaction: transaction.clone(),

--- a/src/swap/db/herc20.rs
+++ b/src/swap/db/herc20.rs
@@ -1,6 +1,6 @@
 use crate::{
     swap::{
-        db::{Database, Load, Save},
+        db::{serialize, Database, Load, Save},
         herc20,
     },
     SwapId,
@@ -47,15 +47,14 @@ impl Save<herc20::Deployed> for Database {
         match stored_swap.herc20_deployed {
             Some(_) => Err(anyhow!("Herc20 Deployed event is already stored")),
             None => {
-                let key = serde_json::to_vec(&swap_id)?;
+                let key = serialize(&swap_id)?;
 
                 let mut swap = stored_swap.clone();
                 swap.herc20_deployed = Some(event.into());
 
-                let old_value = serde_json::to_vec(&stored_swap)
-                    .context("Could not serialize old swap value")?;
-                let new_value =
-                    serde_json::to_vec(&swap).context("Could not serialize new swap value")?;
+                let old_value =
+                    serialize(&stored_swap).context("Could not serialize old swap value")?;
+                let new_value = serialize(&swap).context("Could not serialize new swap value")?;
 
                 self.db
                     .compare_and_swap(key, Some(old_value), Some(new_value))
@@ -112,15 +111,14 @@ impl Save<herc20::Funded> for Database {
         match stored_swap.herc20_funded {
             Some(_) => Err(anyhow!("Herc20 Funded event is already stored")),
             None => {
-                let key = serde_json::to_vec(&swap_id)?;
+                let key = serialize(&swap_id)?;
 
                 let mut swap = stored_swap.clone();
                 swap.herc20_funded = Some(event.into());
 
-                let old_value = serde_json::to_vec(&stored_swap)
-                    .context("Could not serialize old swap value")?;
-                let new_value =
-                    serde_json::to_vec(&swap).context("Could not serialize new swap value")?;
+                let old_value =
+                    serialize(&stored_swap).context("Could not serialize old swap value")?;
+                let new_value = serialize(&swap).context("Could not serialize new swap value")?;
 
                 self.db
                     .compare_and_swap(key, Some(old_value), Some(new_value))
@@ -177,15 +175,14 @@ impl Save<herc20::Redeemed> for Database {
         match stored_swap.herc20_redeemed {
             Some(_) => Err(anyhow!("Herc20 Redeemed event is already stored")),
             None => {
-                let key = serde_json::to_vec(&swap_id)?;
+                let key = serialize(&swap_id)?;
 
                 let mut swap = stored_swap.clone();
                 swap.herc20_redeemed = Some(event.into());
 
-                let old_value = serde_json::to_vec(&stored_swap)
-                    .context("Could not serialize old swap value")?;
-                let new_value =
-                    serde_json::to_vec(&swap).context("Could not serialize new swap value")?;
+                let old_value =
+                    serialize(&stored_swap).context("Could not serialize old swap value")?;
+                let new_value = serialize(&swap).context("Could not serialize new swap value")?;
 
                 self.db
                     .compare_and_swap(key, Some(old_value), Some(new_value))
@@ -239,15 +236,14 @@ impl Save<herc20::Refunded> for Database {
         match stored_swap.herc20_refunded {
             Some(_) => Err(anyhow!("Herc20 Refunded event is already stored")),
             None => {
-                let key = serde_json::to_vec(&swap_id)?;
+                let key = serialize(&swap_id)?;
 
                 let mut swap = stored_swap.clone();
                 swap.herc20_refunded = Some(event.into());
 
-                let old_value = serde_json::to_vec(&stored_swap)
-                    .context("Could not serialize old swap value")?;
-                let new_value =
-                    serde_json::to_vec(&swap).context("Could not serialize new swap value")?;
+                let old_value =
+                    serialize(&stored_swap).context("Could not serialize old swap value")?;
+                let new_value = serialize(&swap).context("Could not serialize new swap value")?;
 
                 self.db
                     .compare_and_swap(key, Some(old_value), Some(new_value))

--- a/src/swap/db/herc20.rs
+++ b/src/swap/db/herc20.rs
@@ -406,7 +406,7 @@ mod tests {
 
         let swap_kind = SwapKind::from((swap, swap_id));
 
-        db.insert_swap(swap_kind).unwrap();
+        db.insert_swap(swap_kind).await.unwrap();
 
         let event = herc20::Deployed {
             transaction: transaction.clone(),
@@ -436,7 +436,7 @@ mod tests {
 
         let swap_kind = SwapKind::from((swap, swap_id));
 
-        db.insert_swap(swap_kind).unwrap();
+        db.insert_swap(swap_kind).await.unwrap();
 
         let event = herc20::Funded {
             transaction: transaction.clone(),
@@ -463,7 +463,7 @@ mod tests {
 
         let swap_kind = SwapKind::from((swap, swap_id));
 
-        db.insert_swap(swap_kind).unwrap();
+        db.insert_swap(swap_kind).await.unwrap();
 
         let event = herc20::Redeemed {
             transaction: transaction.clone(),
@@ -489,7 +489,7 @@ mod tests {
 
         let swap_kind = SwapKind::from((swap, swap_id));
 
-        db.insert_swap(swap_kind).unwrap();
+        db.insert_swap(swap_kind).await.unwrap();
 
         let event = herc20::Refunded {
             transaction: transaction.clone(),

--- a/src/swap_id.rs
+++ b/src/swap_id.rs
@@ -22,3 +22,20 @@ impl fmt::Display for SwapId {
         write!(f, "{}", self.0.to_string())
     }
 }
+
+#[cfg(test)]
+mod arbitrary {
+    use super::*;
+    use quickcheck::{Arbitrary, Gen};
+
+    impl Arbitrary for SwapId {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            let mut bytes = [0u8; 16];
+            for byte in &mut bytes {
+                *byte = u8::arbitrary(g);
+            }
+            let uuid = Uuid::from_bytes(bytes);
+            SwapId(uuid)
+        }
+    }
+}


### PR DESCRIPTION
Few things on the DB:
- Quickcheck tests
- Store values in CBOR instead of JSON: The main reason is that it's a binary format because the DB stores byte arrays. It made less sense to use JSON than CBOR but there is little different considering the usecase.
- flush the db when storing a swap (arguably the most import patch of the PR)