### PR TITLE
Deactivate caching of target dir on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           override: true
 
       - name: Cache target directory
+        if: matrix.os == 'ubuntu-latest'
         uses: actions/cache@v1
         with:
           path: target


### PR DESCRIPTION
To avoid the `serde_derive` not found error.