### PR TITLE
Wallet rescan to pick up funding that happened prior to creating the wallet

### DIFF
--- a/src/bitcoin/bitcoind.rs
+++ b/src/bitcoin/bitcoind.rs
@@ -57,6 +57,23 @@ impl Client {
         Ok(response)
     }
 
+    pub async fn rescan(&self, wallet_name: &str) -> anyhow::Result<RescanResponse> {
+        let response = self
+            .rpc_client
+            .send_with_path(
+                format!("/wallet/{}", wallet_name),
+                jsonrpc::Request::new(
+                    "rescanblockchain",
+                    Vec::<serde_json::Value>::new(),
+                    JSONRPC_VERSION.into(),
+                ),
+            )
+            .await
+            .context("failed to rescan")?;
+
+        Ok(response)
+    }
+
     pub async fn get_balance(
         &self,
         wallet_name: &str,
@@ -316,6 +333,12 @@ pub struct BlockHash(String);
 pub struct CreateWalletResponse {
     name: String,
     warning: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RescanResponse {
+    start_height: usize,
+    stop_height: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]

--- a/src/bitcoin/wallet.rs
+++ b/src/bitcoin/wallet.rs
@@ -52,26 +52,29 @@ impl Wallet {
                     .create_wallet(&self.name, None, Some(true), None, None)
                     .await?;
 
-                self.bitcoind_client.rescan(&self.name).await?;
-
                 let wif = self.seed_as_wif();
 
                 self.bitcoind_client
                     .set_hd_seed(&self.name, Some(true), Some(wif))
-                    .await
+                    .await?;
+
+                self.bitcoind_client.rescan(&self.name).await?;
+
+                Ok(())
             }
             Ok(WalletInfoResponse {
                 hd_seed_id: None, ..
             }) => {
-                // Rescan wallet to ensure funding is picked up
-                self.bitcoind_client.rescan(&self.name).await?;
-
                 // The wallet may have been previously created, but the `sethdseed` call may have failed
                 let wif = self.seed_as_wif();
 
                 self.bitcoind_client
                     .set_hd_seed(&self.name, Some(true), Some(wif))
-                    .await
+                    .await?;
+
+                // Rescan wallet to ensure funding is picked up
+                self.bitcoind_client.rescan(&self.name).await?;
+                Ok(())
             }
             _ => {
                 // Rescan wallet to ensure funding is picked up

--- a/src/bitcoin/wallet.rs
+++ b/src/bitcoin/wallet.rs
@@ -76,11 +76,7 @@ impl Wallet {
                 self.bitcoind_client.rescan(&self.name).await?;
                 Ok(())
             }
-            _ => {
-                // Rescan wallet to ensure funding is picked up
-                self.bitcoind_client.rescan(&self.name).await?;
-                Ok(())
-            }
+            _ => Ok(()),
         }
     }
 

--- a/src/bitcoin/wallet.rs
+++ b/src/bitcoin/wallet.rs
@@ -52,6 +52,8 @@ impl Wallet {
                     .create_wallet(&self.name, None, Some(true), None, None)
                     .await?;
 
+                self.bitcoind_client.rescan(&self.name).await?;
+
                 let wif = self.seed_as_wif();
 
                 self.bitcoind_client
@@ -61,6 +63,9 @@ impl Wallet {
             Ok(WalletInfoResponse {
                 hd_seed_id: None, ..
             }) => {
+                // Rescan wallet to ensure funding is picked up
+                self.bitcoind_client.rescan(&self.name).await?;
+
                 // The wallet may have been previously created, but the `sethdseed` call may have failed
                 let wif = self.seed_as_wif();
 
@@ -68,7 +73,11 @@ impl Wallet {
                     .set_hd_seed(&self.name, Some(true), Some(wif))
                     .await
             }
-            _ => Ok(()),
+            _ => {
+                // Rescan wallet to ensure funding is picked up
+                self.bitcoind_client.rescan(&self.name).await?;
+                Ok(())
+            }
         }
     }
 

--- a/src/test_harness/bitcoin.rs
+++ b/src/test_harness/bitcoin.rs
@@ -40,6 +40,8 @@ impl<'c> Blockchain<'c> {
             .create_wallet(&self.wallet_name, None, None, None, None)
             .await?;
 
+        bitcoind_client.rescan(&self.wallet_name).await?;
+
         let reward_address = bitcoind_client
             .get_new_address(&self.wallet_name, None, None)
             .await?;

--- a/src/test_harness/bitcoin.rs
+++ b/src/test_harness/bitcoin.rs
@@ -40,8 +40,6 @@ impl<'c> Blockchain<'c> {
             .create_wallet(&self.wallet_name, None, None, None, None)
             .await?;
 
-        bitcoind_client.rescan(&self.wallet_name).await?;
-
         let reward_address = bitcoind_client
             .get_new_address(&self.wallet_name, None, None)
             .await?;


### PR DESCRIPTION
When funding the deposit address prior to creating the wallet the funding is not picked up. 
Adding `rescan` fixes this.