### PR TITLE
Introduce seed for network purposes

### DIFF
--- a/src/bitcoin/wallet.rs
+++ b/src/bitcoin/wallet.rs
@@ -254,10 +254,6 @@ impl Wallet {
             hash[0], hash[1], hash[2], hash[3]
         )
     }
-
-    pub fn seed(&self) -> Seed {
-        self.seed
-    }
 }
 
 #[cfg(all(test, feature = "test-docker"))]

--- a/src/command/trade.rs
+++ b/src/command/trade.rs
@@ -47,7 +47,7 @@ pub async fn trade(
     let db = Arc::new(Database::new_test()?);
 
     let mut swarm = Swarm::new(
-        &seed,
+        network::Seed::new(seed.bytes()),
         &settings,
         Arc::clone(&bitcoin_wallet),
         Arc::clone(&ethereum_wallet),


### PR DESCRIPTION
Instead of carrying around the root seed that is used to initialised
the crypto wallets, we used a `network::Seed` for network purposes.

The aim here is to protect the wallet seed from any bug in the network
module that would leak it.

It also removes the indirection of getting the seed via the Bitcoin
wallet.