### PR TITLE
Switch to Price/Quantity model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "comit"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/comit-rs/?rev=cc450c425b52e060371d0384a759cd0eab13396c#cc450c425b52e060371d0384a759cd0eab13396c"
+source = "git+https://github.com/comit-network/comit-rs/?rev=76854090bb542ab55c5649c98ad1bc887bf5c764#76854090bb542ab55c5649c98ad1bc887bf5c764"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -560,7 +560,7 @@ dependencies = [
  "strum 0.19.2",
  "strum_macros 0.19.2",
  "thiserror",
- "time 0.2.16",
+ "time 0.2.17",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -597,6 +597,12 @@ name = "conquer-util"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "654fb2472cc369d311c547103a1fa81d467bef370ae7a0680f65939895b1182a"
+
+[[package]]
+name = "const_fn"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce90df4c658c62f12d78f7508cf92f9173e5184a539c10bfe54a3107b3ffd0f2"
 
 [[package]]
 name = "constant_time_eq"
@@ -775,7 +781,7 @@ dependencies = [
 [[package]]
 name = "digest"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/comit-rs/?rev=cc450c425b52e060371d0384a759cd0eab13396c#cc450c425b52e060371d0384a759cd0eab13396c"
+source = "git+https://github.com/comit-network/comit-rs/?rev=76854090bb542ab55c5649c98ad1bc887bf5c764#76854090bb542ab55c5649c98ad1bc887bf5c764"
 dependencies = [
  "digest-macro-derive",
  "hex 0.4.2",
@@ -802,7 +808,7 @@ dependencies = [
 [[package]]
 name = "digest-macro-derive"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/comit-rs/?rev=cc450c425b52e060371d0384a759cd0eab13396c#cc450c425b52e060371d0384a759cd0eab13396c"
+source = "git+https://github.com/comit-network/comit-rs/?rev=76854090bb542ab55c5649c98ad1bc887bf5c764#76854090bb542ab55c5649c98ad1bc887bf5c764"
 dependencies = [
  "hex 0.4.2",
  "proc-macro2 1.0.19",
@@ -2049,7 +2055,7 @@ dependencies = [
  "tempdir",
  "testcontainers",
  "thiserror",
- "time 0.2.16",
+ "time 0.2.17",
  "tokio",
  "toml",
  "tracing",
@@ -3808,11 +3814,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a51cadc5b1eec673a685ff7c33192ff7b7603d0b75446fb354939ee615acb15"
+checksum = "ca7ec98a72285d12e0febb26f0847b12d54be24577618719df654c66cadab55d"
 dependencies = [
- "cfg-if",
+ "const_fn",
  "libc",
  "serde 1.0.114",
  "standback",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ async-trait = "0.1"
 bitcoin = { version = "0.23", features = ["rand", "use-serde"] }
 chrono = "0.4"
 clarity = "0.1"
-comit = { git = "https://github.com/comit-network/comit-rs/", package = "comit", rev = "cc450c425b52e060371d0384a759cd0eab13396c" }
+comit = { git = "https://github.com/comit-network/comit-rs/", package = "comit", rev = "76854090bb542ab55c5649c98ad1bc887bf5c764" }
 config = "0.10"
 conquer-once = "0.2"
 csv = "1.1"

--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -1,8 +1,8 @@
-mod amount;
+pub mod amount;
 mod bitcoind;
 mod wallet;
 
 pub use ::bitcoin::{Address, Network, Txid};
-pub use amount::{Amount, Asset, SATS_IN_BITCOIN_EXP};
+pub use amount::{Amount, SATS_IN_BITCOIN_EXP};
 pub use bitcoind::*;
 pub use wallet::Wallet;

--- a/src/bitcoin/amount.rs
+++ b/src/bitcoin/amount.rs
@@ -3,15 +3,9 @@ use crate::{
     float_maths::string_int_to_float,
     Rate,
 };
-use ::bitcoin::Network;
+use comit::{asset::Bitcoin, Quantity};
 
 pub const SATS_IN_BITCOIN_EXP: u16 = 8;
-
-#[derive(Debug, Copy, Clone, Ord, PartialOrd, PartialEq, Eq)]
-pub struct Asset {
-    pub amount: Amount,
-    pub network: Network,
-}
 
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, PartialEq, Eq, Default)]
 pub struct Amount(::bitcoin::Amount);
@@ -88,15 +82,27 @@ impl From<Amount> for ::bitcoin::Amount {
     }
 }
 
+impl From<Amount> for comit::asset::Bitcoin {
+    fn from(from: Amount) -> Self {
+        Self::from_sat(from.as_sat())
+    }
+}
+
 impl From<comit::asset::Bitcoin> for Amount {
     fn from(from: comit::asset::Bitcoin) -> Self {
         Self(from.into())
     }
 }
 
-impl From<Amount> for comit::asset::Bitcoin {
-    fn from(from: Amount) -> Self {
-        Self::from_sat(from.as_sat())
+impl From<comit::Quantity<comit::asset::Bitcoin>> for Amount {
+    fn from(from: comit::Quantity<comit::asset::Bitcoin>) -> Self {
+        Self::from_sat(from.sats())
+    }
+}
+
+impl Into<comit::Quantity<comit::asset::Bitcoin>> for Amount {
+    fn into(self) -> Quantity<Bitcoin> {
+        Quantity::new(comit::asset::Bitcoin::from_sat(self.as_sat()))
     }
 }
 
@@ -108,13 +114,13 @@ impl std::fmt::Display for Amount {
 }
 
 #[cfg(test)]
-impl crate::StaticStub for Asset {
-    fn static_stub() -> Self {
-        Self {
-            amount: Amount::default(),
-            network: Network::Bitcoin,
-        }
-    }
+pub fn btc(btc: f64) -> Amount {
+    Amount::from_btc(btc).unwrap()
+}
+
+#[cfg(test)]
+pub fn some_btc(btc: f64) -> Option<Amount> {
+    Some(Amount::from_btc(btc).unwrap())
 }
 
 #[cfg(test)]

--- a/src/command/resume_only.rs
+++ b/src/command/resume_only.rs
@@ -24,10 +24,7 @@ pub async fn resume_only(
         settings.data.dir.join("history.csv").as_path(),
     )?));
 
-    let bitcoin_connector = Arc::new(BitcoindConnector::new(
-        settings.bitcoin.bitcoind.node_url,
-        settings.bitcoin.network,
-    )?);
+    let bitcoin_connector = Arc::new(BitcoindConnector::new(settings.bitcoin.bitcoind.node_url)?);
     let ethereum_connector = Arc::new(Web3Connector::new(settings.ethereum.node_url));
 
     respawn_swaps(

--- a/src/command/trade.rs
+++ b/src/command/trade.rs
@@ -344,11 +344,13 @@ fn handle_rate_update(
                     new_sell_order,
                     new_buy_order,
                 })) => {
-                    swarm.publish(
+                    swarm.orderbook.publish(
                         new_sell_order.to_comit_order(maker.swap_protocol(Position::Sell)),
                     );
-                    swarm.publish(new_buy_order.to_comit_order(maker.swap_protocol(Position::Buy)));
-                    swarm.clear_own_orders();
+                    swarm
+                        .orderbook
+                        .publish(new_buy_order.to_comit_order(maker.swap_protocol(Position::Buy)));
+                    swarm.orderbook.clear_own_orders();
                 }
 
                 Ok(None) => (),

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use comit::btsieve::{bitcoin::BitcoindConnector, ethereum::Web3Connector};
 use comit::ethereum::ChainId;
+use comit::ledger;
 use std::fmt::Debug;
 use thiserror::Error;
 
@@ -21,8 +22,8 @@ pub trait FetchNetworkId<S>: Send + Sync + 'static {
 }
 
 #[async_trait]
-impl FetchNetworkId<bitcoin::Network> for BitcoindConnector {
-    async fn network_id(&self) -> anyhow::Result<bitcoin::Network> {
+impl FetchNetworkId<ledger::Bitcoin> for BitcoindConnector {
+    async fn network_id(&self) -> anyhow::Result<ledger::Bitcoin> {
         let chain = self.chain_info().await?.chain;
 
         Ok(chain)

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,5 +1,5 @@
 use crate::swap::{Database, SwapParams};
-use crate::{bitcoin, ethereum, ethereum::dai, order::BtcDaiOrderForm, swap::SwapKind, SwapId};
+use crate::{bitcoin, ethereum, order::BtcDaiOrderForm, swap::SwapKind, SwapId};
 use ::bitcoin::hashes::{sha256, Hash, HashEngine};
 use chrono::{NaiveDateTime, Utc};
 use comit::{
@@ -264,21 +264,12 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<::comit::network::orderbook::Be
                 let bitcoin_identity =
                     identity::Bitcoin::from_secret_key(&crate::SECP, &bitcoin_transient_sk);
 
-                let erc20_quantity = quantity.as_sat() * price;
+                let erc20_quantity = quantity * price.clone();
 
                 let form = BtcDaiOrderForm {
                     position: our_position,
-                    base: bitcoin::Asset {
-                        amount: quantity.into(),
-                        network: self.bitcoin_network(),
-                    },
-                    quote: dai::Asset {
-                        amount: dai::Amount::from(erc20_quantity.clone()),
-                        chain: ethereum::Chain::Local {
-                            chain_id: u32::from(self.ethereum_chain_id()),
-                            dai_contract_address: token_contract,
-                        },
-                    },
+                    quantity,
+                    price,
                 };
 
                 let (role_dependant_params, common_params, swap_protocol) = match swap_protocol {
@@ -309,11 +300,11 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<::comit::network::orderbook::Be
                                         token_contract,
                                         quantity: erc20_quantity,
                                     },
-                                    bitcoin: quantity,
+                                    bitcoin: quantity.to_inner(),
                                     ethereum_absolute_expiry,
                                     bitcoin_absolute_expiry,
                                     ethereum_chain_id: self.ethereum_chain_id(),
-                                    bitcoin_network: self.bitcoin_network(),
+                                    bitcoin_network: self.bitcoin_network().into(),
                                 },
                                 comit::network::setup_swap::SwapProtocol::HbitHerc20,
                             ),
@@ -328,11 +319,11 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<::comit::network::orderbook::Be
                                         token_contract,
                                         quantity: erc20_quantity,
                                     },
-                                    bitcoin: quantity,
+                                    bitcoin: quantity.to_inner(),
                                     ethereum_absolute_expiry,
                                     bitcoin_absolute_expiry,
                                     ethereum_chain_id: self.ethereum_chain_id(),
-                                    bitcoin_network: self.bitcoin_network(),
+                                    bitcoin_network: self.bitcoin_network().into(),
                                 },
                                 comit::network::setup_swap::SwapProtocol::HbitHerc20,
                             ),
@@ -366,11 +357,11 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<::comit::network::orderbook::Be
                                         token_contract,
                                         quantity: erc20_quantity,
                                     },
-                                    bitcoin: quantity,
+                                    bitcoin: quantity.to_inner(),
                                     ethereum_absolute_expiry,
                                     bitcoin_absolute_expiry,
                                     ethereum_chain_id: self.ethereum_chain_id(),
-                                    bitcoin_network: self.bitcoin_network(),
+                                    bitcoin_network: self.bitcoin_network().into(),
                                 },
                                 comit::network::setup_swap::SwapProtocol::Herc20Hbit,
                             ),
@@ -384,11 +375,11 @@ impl libp2p::swarm::NetworkBehaviourEventProcess<::comit::network::orderbook::Be
                                         token_contract,
                                         quantity: erc20_quantity,
                                     },
-                                    bitcoin: quantity,
+                                    bitcoin: quantity.to_inner(),
                                     ethereum_absolute_expiry,
                                     bitcoin_absolute_expiry,
                                     ethereum_chain_id: self.ethereum_chain_id(),
-                                    bitcoin_network: self.bitcoin_network(),
+                                    bitcoin_network: self.bitcoin_network().into(),
                                 },
                                 comit::network::setup_swap::SwapProtocol::Herc20Hbit,
                             ),

--- a/src/order.rs
+++ b/src/order.rs
@@ -1,13 +1,10 @@
-use crate::{
-    bitcoin,
-    ethereum::{self, dai},
-    Rate, Spread,
+use crate::{bitcoin, ethereum::dai, Rate, Spread};
+use comit::{
+    asset::{Bitcoin, Erc20Quantity},
+    order::SwapProtocol,
+    Position, Price, Quantity,
 };
-
-use comit::asset::ethereum::TryFromWei;
-use comit::{order::SwapProtocol, Position};
-use std::fmt::{Display, Formatter};
-use std::{cmp::min, convert::TryFrom, fmt};
+use std::cmp::min;
 
 #[derive(Debug, Copy, Clone, strum_macros::Display)]
 #[strum(serialize_all = "UPPERCASE")]
@@ -16,32 +13,25 @@ pub enum Symbol {
     Dai,
 }
 
-// todo: change to price quantity model
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BtcDaiOrderForm {
     pub position: Position,
-    pub base: bitcoin::Asset,
-    pub quote: dai::Asset,
+    pub quantity: Quantity<Bitcoin>,
+    pub price: Price<Bitcoin, Erc20Quantity>,
 }
 
-// todo: this will go when price quantity model is introduced
 impl BtcDaiOrderForm {
-    pub fn to_order_comit_order(
-        &self,
-        swap_protocol: SwapProtocol,
-    ) -> anyhow::Result<comit::BtcDaiOrder> {
-        let rate = Rate::try_from(BtcDaiOrderForm {
-            position: self.position,
-            base: self.base,
-            quote: self.quote.clone(),
-        })?;
-
-        Ok(comit::BtcDaiOrder::new(
+    pub fn to_comit_order(&self, swap_protocol: SwapProtocol) -> comit::BtcDaiOrder {
+        comit::BtcDaiOrder::new(
             self.position,
-            comit::asset::Bitcoin::from_sat(self.base.amount.as_sat()),
-            comit::asset::Erc20Quantity::try_from_wei(rate.integer())?,
+            self.quantity,
+            self.price.clone(),
             swap_protocol,
-        ))
+        )
+    }
+
+    pub fn quote(&self) -> Erc20Quantity {
+        self.quantity * self.price.clone()
     }
     #[allow(clippy::too_many_arguments)]
     pub fn new_sell(
@@ -51,8 +41,6 @@ impl BtcDaiOrderForm {
         max_amount: Option<bitcoin::Amount>,
         mid_market_rate: Rate,
         spread: Spread,
-        bitcoin_network: bitcoin::Network,
-        dai_chain: ethereum::Chain,
     ) -> anyhow::Result<BtcDaiOrderForm> {
         if let Some(max_amount) = max_amount {
             if max_amount < base_fees {
@@ -74,23 +62,12 @@ impl BtcDaiOrderForm {
             None => base_balance - base_reserved_funds - base_fees,
         };
 
-        let base = bitcoin::Asset {
-            amount: base_amount,
-            network: bitcoin_network,
-        };
-
         let rate = spread.apply(mid_market_rate, Position::Sell)?;
-        let quote_amount = base_amount.worth_in(rate);
-
-        let quote = dai::Asset {
-            amount: quote_amount,
-            chain: dai_chain,
-        };
 
         Ok(BtcDaiOrderForm {
             position: Position::Sell,
-            base,
-            quote,
+            quantity: base_amount.into(),
+            price: rate.into(),
         })
     }
 
@@ -101,8 +78,6 @@ impl BtcDaiOrderForm {
         max_amount: Option<dai::Amount>,
         mid_market_rate: Rate,
         spread: Spread,
-        bitcoin_network: bitcoin::Network,
-        dai_chain: ethereum::Chain,
     ) -> anyhow::Result<BtcDaiOrderForm> {
         if quote_balance <= quote_reserved_funds {
             anyhow::bail!(InsufficientFunds(Symbol::Dai))
@@ -116,25 +91,15 @@ impl BtcDaiOrderForm {
         let rate = spread.apply(mid_market_rate, Position::Buy)?;
         let base_amount = quote_amount.worth_in(rate)?;
 
-        let base = bitcoin::Asset {
-            amount: base_amount,
-            network: bitcoin_network,
-        };
-
-        let quote = dai::Asset {
-            amount: quote_amount,
-            chain: dai_chain,
-        };
-
         Ok(BtcDaiOrderForm {
             position: Position::Buy,
-            base,
-            quote,
+            quantity: base_amount.into(),
+            price: rate.into(),
         })
     }
 
     pub fn is_as_profitable_as(&self, profitable_rate: Rate) -> anyhow::Result<bool> {
-        let order_rate = Rate::try_from(self.clone())?;
+        let order_rate = self.price.clone();
         match self.position {
             Position::Buy => {
                 // We are buying BTC for DAI
@@ -142,7 +107,7 @@ impl BtcDaiOrderForm {
                 // It is NOT profitable to buy, if the current rate is greater than the order rate.
                 // 1:8800 -> We give less DAI for getting BTC -> Good.
                 // 1:9200 -> We have to give more DAI for getting BTC -> Sucks.
-                Ok(order_rate <= profitable_rate)
+                Ok(order_rate <= profitable_rate.into())
             }
             Position::Sell => {
                 // We are selling BTC for DAI
@@ -150,22 +115,9 @@ impl BtcDaiOrderForm {
                 // It is NOT profitable to sell, if the current rate is smaller than the order rate.
                 // 1:8800 -> We get less DAI for our BTC -> Sucks.
                 // 1:9200 -> We get more DAI for our BTC -> Good.
-                Ok(order_rate >= profitable_rate)
+                Ok(order_rate >= profitable_rate.into())
             }
         }
-    }
-}
-
-impl Display for BtcDaiOrderForm {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}, {}, {}",
-            self.position.to_string(),
-            self.base.amount.to_string(),
-            self.quote.amount.to_string()
-        )?;
-        Ok(())
     }
 }
 
@@ -199,49 +151,39 @@ pub trait Fees {
 #[cfg(test)]
 impl crate::StaticStub for BtcDaiOrderForm {
     fn static_stub() -> Self {
+        use std::convert::TryFrom;
         Self {
             position: Position::Buy,
-            base: bitcoin::Asset {
-                amount: bitcoin::Amount::from_sat(1),
-                network: bitcoin::Network::Bitcoin,
-            },
-            quote: dai::Asset {
-                amount: dai::Amount::from_atto(num::BigUint::from(1u8)),
-                chain: ethereum::Chain::static_stub(),
-            },
+            quantity: Quantity::new(Bitcoin::from_sat(1)),
+            price: Rate::try_from(1.0).unwrap().into(),
         }
+    }
+}
+
+#[cfg(test)]
+pub fn btc_dai_order_form(
+    position: Position,
+    btc_quantity: bitcoin::Amount,
+    btc_dai_rate: Rate,
+) -> BtcDaiOrderForm {
+    BtcDaiOrderForm {
+        position,
+        quantity: btc_quantity.into(),
+        price: btc_dai_rate.into(),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{MidMarketRate, Rate, StaticStub};
+
+    use crate::{
+        bitcoin, bitcoin::amount::btc, ethereum::dai::dai, rate::rate, MidMarketRate, Rate,
+    };
+
     use num::BigUint;
     use proptest::prelude::*;
     use std::{convert::TryFrom, str::FromStr};
-
-    fn btc(btc: f64) -> bitcoin::Amount {
-        bitcoin::Amount::from_btc(btc).unwrap()
-    }
-
-    fn btc_asset(amount: f64) -> bitcoin::Asset {
-        bitcoin::Asset {
-            amount: btc(amount),
-            network: bitcoin::Network::Bitcoin,
-        }
-    }
-
-    fn dai_amount(dai: f64) -> dai::Amount {
-        dai::Amount::from_dai_trunc(dai).unwrap()
-    }
-
-    fn dai_asset(dai: f64) -> dai::Asset {
-        dai::Asset {
-            amount: dai_amount(dai),
-            chain: ethereum::Chain::static_stub(),
-        }
-    }
 
     #[test]
     fn given_a_balance_return_order_selling_full_balance() {
@@ -253,25 +195,21 @@ mod tests {
             Some(btc(100.0)),
             rate,
             Spread::new(0).unwrap(),
-            bitcoin::Network::Bitcoin,
-            ethereum::Chain::Mainnet,
         )
         .unwrap();
 
-        assert_eq!(order.base, btc_asset(10.0));
+        assert_eq!(bitcoin::Amount::from(order.quantity), btc(10.0));
 
         let order = BtcDaiOrderForm::new_buy(
-            dai_amount(10.0),
-            dai_amount(0.0),
-            Some(dai_amount(100.0)),
+            dai(10.0),
+            dai(0.0),
+            Some(dai(100.0)),
             rate,
             Spread::new(0).unwrap(),
-            bitcoin::Network::Bitcoin,
-            ethereum::Chain::Mainnet,
         )
         .unwrap();
 
-        assert_eq!(order.quote, dai_asset(10.0));
+        assert_eq!(dai::Amount::from(order.quote()), dai(10.0));
     }
 
     #[test]
@@ -284,25 +222,16 @@ mod tests {
             Some(btc(100.0)),
             rate,
             Spread::new(0).unwrap(),
-            bitcoin::Network::Bitcoin,
-            ethereum::Chain::Mainnet,
         )
         .unwrap();
 
-        assert_eq!(order.base, btc_asset(8.0));
+        assert_eq!(bitcoin::Amount::from(order.quantity), btc(8.0));
 
-        let order = BtcDaiOrderForm::new_buy(
-            dai_amount(10.0),
-            dai_amount(2.0),
-            None,
-            rate,
-            Spread::new(0).unwrap(),
-            bitcoin::Network::Bitcoin,
-            ethereum::Chain::Mainnet,
-        )
-        .unwrap();
+        let order =
+            BtcDaiOrderForm::new_buy(dai(10.0), dai(2.0), None, rate, Spread::new(0).unwrap())
+                .unwrap();
 
-        assert_eq!(order.quote, dai_asset(8.0));
+        assert_eq!(dai::Amount::from(order.quote()), dai(8.0));
     }
 
     #[test]
@@ -315,42 +244,36 @@ mod tests {
             Some(btc(2.0)),
             rate,
             Spread::new(0).unwrap(),
-            bitcoin::Network::Bitcoin,
-            ethereum::Chain::Mainnet,
         )
         .unwrap();
 
-        assert_eq!(order.base, btc_asset(2.0));
+        assert_eq!(bitcoin::Amount::from(order.quantity), btc(2.0));
 
         let order = BtcDaiOrderForm::new_buy(
-            dai_amount(10.0),
-            dai_amount(2.0),
-            Some(dai_amount(2.0)),
+            dai(10.0),
+            dai(2.0),
+            Some(dai(2.0)),
             rate,
             Spread::new(0).unwrap(),
-            bitcoin::Network::Bitcoin,
-            ethereum::Chain::Mainnet,
         )
         .unwrap();
 
-        assert_eq!(order.quote, dai_asset(2.0));
+        assert_eq!(dai::Amount::from(order.quote()), dai(2.0));
     }
 
     #[test]
     fn given_an_available_balance_and_fees_sell_balance_minus_fees() {
         let rate = Rate::try_from(1.0).unwrap();
         let order = BtcDaiOrderForm::new_buy(
-            dai_amount(10.0),
-            dai_amount(3.0),
-            Some(dai_amount(1.0)),
+            dai(10.0),
+            dai(3.0),
+            Some(dai(1.0)),
             rate,
             Spread::new(0).unwrap(),
-            bitcoin::Network::Bitcoin,
-            ethereum::Chain::Mainnet,
         )
         .unwrap();
 
-        assert_eq!(order.quote, dai_asset(1.0));
+        assert_eq!(dai::Amount::from(order.quote()), dai(1.0));
     }
 
     #[test]
@@ -358,68 +281,32 @@ mod tests {
         let spread = Spread::new(0).unwrap();
 
         let rate = Rate::try_from(0.1).unwrap();
-        let order = BtcDaiOrderForm::new_sell(
-            btc(1051.0),
-            btc(1.0),
-            btc(50.0),
-            None,
-            rate,
-            spread,
-            bitcoin::Network::Bitcoin,
-            ethereum::Chain::Mainnet,
-        )
-        .unwrap();
+        let order = BtcDaiOrderForm::new_sell(btc(1051.0), btc(1.0), btc(50.0), None, rate, spread)
+            .unwrap();
 
         // 1 Sell => 0.1 Buy
         // 1000 Sell => 100 Buy
-        assert_eq!(order.base, btc_asset(1000.0));
-        assert_eq!(order.quote, dai_asset(100.0));
+        assert_eq!(bitcoin::Amount::from(order.quantity), btc(1000.0));
+        assert_eq!(dai::Amount::from(order.quote()), dai(100.0));
 
         let rate = Rate::try_from(10.0).unwrap();
-        let order = BtcDaiOrderForm::new_sell(
-            btc(1051.0),
-            btc(1.0),
-            btc(50.0),
-            None,
-            rate,
-            spread,
-            bitcoin::Network::Bitcoin,
-            ethereum::Chain::Mainnet,
-        )
-        .unwrap();
+        let order = BtcDaiOrderForm::new_sell(btc(1051.0), btc(1.0), btc(50.0), None, rate, spread)
+            .unwrap();
 
-        assert_eq!(order.base, btc_asset(1000.0));
-        assert_eq!(order.quote, dai_asset(10_000.0));
+        assert_eq!(bitcoin::Amount::from(order.quantity), btc(1000.0));
+        assert_eq!(dai::Amount::from(order.quote()), dai(10_000.0));
 
         let rate = Rate::try_from(0.1).unwrap();
-        let order = BtcDaiOrderForm::new_buy(
-            dai_amount(1050.0),
-            dai_amount(50.0),
-            None,
-            rate,
-            spread,
-            bitcoin::Network::Bitcoin,
-            ethereum::Chain::Mainnet,
-        )
-        .unwrap();
+        let order = BtcDaiOrderForm::new_buy(dai(1050.0), dai(50.0), None, rate, spread).unwrap();
 
-        assert_eq!(order.base, btc_asset(10_000.0));
-        assert_eq!(order.quote, dai_asset(1000.0));
+        assert_eq!(bitcoin::Amount::from(order.quantity), btc(10_000.0));
+        assert_eq!(dai::Amount::from(order.quote()), dai(1000.0));
 
         let rate = Rate::try_from(10.0).unwrap();
-        let order = BtcDaiOrderForm::new_buy(
-            dai_amount(1050.0),
-            dai_amount(50.0),
-            None,
-            rate,
-            spread,
-            bitcoin::Network::Bitcoin,
-            ethereum::Chain::Mainnet,
-        )
-        .unwrap();
+        let order = BtcDaiOrderForm::new_buy(dai(1050.0), dai(50.0), None, rate, spread).unwrap();
 
-        assert_eq!(order.base, btc_asset(100.0));
-        assert_eq!(order.quote, dai_asset(1000.0));
+        assert_eq!(bitcoin::Amount::from(order.quantity), btc(100.0));
+        assert_eq!(dai::Amount::from(order.quote()), dai(1000.0));
     }
 
     #[test]
@@ -427,34 +314,16 @@ mod tests {
         let rate = Rate::try_from(10_000.0).unwrap();
         let spread = Spread::new(300).unwrap();
 
-        let order = BtcDaiOrderForm::new_sell(
-            btc(1.51),
-            btc(0.01),
-            btc(0.5),
-            None,
-            rate,
-            spread,
-            bitcoin::Network::Bitcoin,
-            ethereum::Chain::Mainnet,
-        )
-        .unwrap();
+        let order =
+            BtcDaiOrderForm::new_sell(btc(1.51), btc(0.01), btc(0.5), None, rate, spread).unwrap();
 
-        assert_eq!(order.base, btc_asset(1.0));
-        assert_eq!(order.quote, dai_asset(10_300.0));
+        assert_eq!(bitcoin::Amount::from(order.quantity), btc(1.0));
+        assert_eq!(dai::Amount::from(order.quote()), dai(10_300.0));
 
-        let order = BtcDaiOrderForm::new_buy(
-            dai_amount(10_051.0),
-            dai_amount(51.0),
-            None,
-            rate,
-            spread,
-            bitcoin::Network::Bitcoin,
-            ethereum::Chain::Mainnet,
-        )
-        .unwrap();
+        let order = BtcDaiOrderForm::new_buy(dai(10_051.0), dai(51.0), None, rate, spread).unwrap();
 
-        assert_eq!(order.base, btc_asset(1.03092783));
-        assert_eq!(order.quote, dai_asset(10_000.0));
+        assert_eq!(bitcoin::Amount::from(order.quantity), btc(1.03092783));
+        assert_eq!(dai::Amount::from(order.quote()), dai(10_000.0));
     }
 
     #[test]
@@ -462,27 +331,10 @@ mod tests {
         let rate = Rate::try_from(1.0).unwrap();
         let spread = Spread::new(0).unwrap();
 
-        let result = BtcDaiOrderForm::new_sell(
-            btc(1.0),
-            btc(2.0),
-            btc(0.0),
-            None,
-            rate,
-            spread,
-            bitcoin::Network::Bitcoin,
-            ethereum::Chain::Mainnet,
-        );
+        let result = BtcDaiOrderForm::new_sell(btc(1.0), btc(2.0), btc(0.0), None, rate, spread);
         assert!(result.unwrap_err().downcast::<InsufficientFunds>().is_ok());
 
-        let result = BtcDaiOrderForm::new_buy(
-            dai_amount(1.0),
-            dai_amount(2.0),
-            None,
-            rate,
-            spread,
-            bitcoin::Network::Bitcoin,
-            ethereum::Chain::Mainnet,
-        );
+        let result = BtcDaiOrderForm::new_buy(dai(1.0), dai(2.0), None, rate, spread);
         assert!(result.unwrap_err().downcast::<InsufficientFunds>().is_ok());
     }
 
@@ -491,37 +343,16 @@ mod tests {
         let rate = Rate::try_from(1.0).unwrap();
         let spread = Spread::new(0).unwrap();
 
-        let result = BtcDaiOrderForm::new_sell(
-            btc(1.0),
-            btc(0.0),
-            btc(2.0),
-            None,
-            rate,
-            spread,
-            bitcoin::Network::Bitcoin,
-            ethereum::Chain::Mainnet,
-        );
+        let result = BtcDaiOrderForm::new_sell(btc(1.0), btc(0.0), btc(2.0), None, rate, spread);
         assert!(result.unwrap_err().downcast::<InsufficientFunds>().is_ok());
 
-        let result = BtcDaiOrderForm::new_buy(
-            dai_amount(1.0),
-            dai_amount(2.0),
-            None,
-            rate,
-            spread,
-            bitcoin::Network::Bitcoin,
-            ethereum::Chain::Mainnet,
-        );
+        let result = BtcDaiOrderForm::new_buy(dai(1.0), dai(2.0), None, rate, spread);
         assert!(result.unwrap_err().downcast::<InsufficientFunds>().is_ok());
     }
 
     #[test]
     fn sell_order_is_as_good_as_market_rate() {
-        let order = BtcDaiOrderForm {
-            position: Position::Sell,
-            base: btc_asset(1.0),
-            quote: dai_asset(1.0),
-        };
+        let order = btc_dai_order_form(Position::Sell, btc(1.0), rate(1.0));
 
         let rate = MidMarketRate::new(Rate::try_from(1.0).unwrap());
 
@@ -531,11 +362,7 @@ mod tests {
 
     #[test]
     fn sell_order_is_better_than_market_rate() {
-        let order = BtcDaiOrderForm {
-            position: Position::Sell,
-            base: btc_asset(1.0),
-            quote: dai_asset(1.0),
-        };
+        let order = btc_dai_order_form(Position::Sell, btc(1.0), rate(1.0));
 
         let rate = MidMarketRate::new(Rate::try_from(0.9).unwrap());
 
@@ -545,11 +372,7 @@ mod tests {
 
     #[test]
     fn sell_order_is_worse_than_market_rate() {
-        let order = BtcDaiOrderForm {
-            position: Position::Sell,
-            base: btc_asset(1.0),
-            quote: dai_asset(1.0),
-        };
+        let order = btc_dai_order_form(Position::Sell, btc(1.0), rate(1.0));
 
         let rate = MidMarketRate::new(Rate::try_from(1.1).unwrap());
 
@@ -559,11 +382,7 @@ mod tests {
 
     #[test]
     fn buy_order_is_as_good_as_market_rate() {
-        let order = BtcDaiOrderForm {
-            position: Position::Buy,
-            base: btc_asset(1.0),
-            quote: dai_asset(1.0),
-        };
+        let order = btc_dai_order_form(Position::Buy, btc(1.0), rate(1.0));
 
         let rate = MidMarketRate::new(Rate::try_from(1.0).unwrap());
 
@@ -573,11 +392,7 @@ mod tests {
 
     #[test]
     fn buy_order_is_better_than_market_rate() {
-        let order = BtcDaiOrderForm {
-            position: Position::Buy,
-            base: btc_asset(1.0),
-            quote: dai_asset(1.0),
-        };
+        let order = btc_dai_order_form(Position::Buy, btc(1.0), rate(1.0));
 
         let rate = MidMarketRate::new(Rate::try_from(1.1).unwrap());
 
@@ -587,11 +402,7 @@ mod tests {
 
     #[test]
     fn buy_order_is_worse_than_market_rate() {
-        let order = BtcDaiOrderForm {
-            position: Position::Buy,
-            base: btc_asset(1.0),
-            quote: dai_asset(1.0),
-        };
+        let order = btc_dai_order_form(Position::Buy, btc(1.0), rate(1.0));
 
         let rate = MidMarketRate::new(Rate::try_from(0.9).unwrap());
 
@@ -614,7 +425,7 @@ mod tests {
                 let dai_reserved_funds = dai::Amount::from_atto(dai_reserved_funds);
                 let dai_max_amount = dai::Amount::from_atto(dai_max_amount);
 
-                let _: anyhow::Result<BtcDaiOrderForm> = BtcDaiOrderForm::new_buy(dai_balance, dai_reserved_funds, Some(dai_max_amount), rate, spread, bitcoin::Network::Bitcoin, ethereum::Chain::Mainnet);
+                let _: anyhow::Result<BtcDaiOrderForm> = BtcDaiOrderForm::new_buy(dai_balance, dai_reserved_funds, Some(dai_max_amount), rate, spread);
             }
         }
     }
@@ -632,7 +443,7 @@ mod tests {
                 let dai_balance = dai::Amount::from_atto(dai_balance);
                 let dai_reserved_funds = dai::Amount::from_atto(dai_reserved_funds);
 
-                let _: anyhow::Result<BtcDaiOrderForm> = BtcDaiOrderForm::new_buy(dai_balance, dai_reserved_funds, None, rate, spread, bitcoin::Network::Bitcoin, ethereum::Chain::Mainnet);
+                let _: anyhow::Result<BtcDaiOrderForm> = BtcDaiOrderForm::new_buy(dai_balance, dai_reserved_funds, None, rate, spread);
             }
         }
     }
@@ -649,7 +460,7 @@ mod tests {
             let spread = Spread::new(spread);
 
             if let (Ok(rate), Ok(spread)) = (rate, spread) {
-                let _: anyhow::Result<BtcDaiOrderForm> = BtcDaiOrderForm::new_sell(btc_balance, btc_fees, btc_reserved_funds, Some(btc_max_amount), rate, spread, bitcoin::Network::Bitcoin, ethereum::Chain::Mainnet);
+                let _: anyhow::Result<BtcDaiOrderForm> = BtcDaiOrderForm::new_sell(btc_balance, btc_fees, btc_reserved_funds, Some(btc_max_amount), rate, spread);
             }
         }
     }
@@ -665,7 +476,7 @@ mod tests {
             let spread = Spread::new(spread);
 
             if let (Ok(rate), Ok(spread)) = (rate, spread) {
-                let _: anyhow::Result<BtcDaiOrderForm> = BtcDaiOrderForm::new_sell(btc_balance, btc_fees, btc_reserved_funds, None, rate, spread, bitcoin::Network::Bitcoin, ethereum::Chain::Mainnet);
+                let _: anyhow::Result<BtcDaiOrderForm> = BtcDaiOrderForm::new_sell(btc_balance, btc_fees, btc_reserved_funds, None, rate, spread);
             }
         }
     }

--- a/src/order.rs
+++ b/src/order.rs
@@ -314,16 +314,26 @@ mod tests {
         let rate = Rate::try_from(10_000.0).unwrap();
         let spread = Spread::new(300).unwrap();
 
+        assert_eq!(
+            spread.apply(rate, Position::Sell).unwrap().integer(),
+            BigUint::from(103000000000000 as u64)
+        );
+
         let order =
             BtcDaiOrderForm::new_sell(btc(1.51), btc(0.01), btc(0.5), None, rate, spread).unwrap();
 
         assert_eq!(bitcoin::Amount::from(order.quantity), btc(1.0));
         assert_eq!(dai::Amount::from(order.quote()), dai(10_300.0));
 
+        assert_eq!(
+            spread.apply(rate, Position::Buy).unwrap().integer(),
+            BigUint::from(97000000000000 as u64)
+        );
+
         let order = BtcDaiOrderForm::new_buy(dai(10_051.0), dai(51.0), None, rate, spread).unwrap();
 
         assert_eq!(bitcoin::Amount::from(order.quantity), btc(1.03092783));
-        assert_eq!(dai::Amount::from(order.quote()), dai(10_000.0));
+        assert_eq!(dai::Amount::from(order.quote()), dai(9999.999951));
     }
 
     #[test]

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -163,7 +163,7 @@ impl crate::StaticStub for SwapParams {
         SwapParams {
             hbit_params: hbit::Params {
                 shared: hbit::SharedParams {
-                    network: ::bitcoin::Network::Regtest,
+                    network: comit::ledger::Bitcoin::Regtest,
                     asset: comit::asset::Bitcoin::from_sat(12_345_678),
                     redeem_identity: comit::bitcoin::PublicKey::from_str(
                         "039b6347398505f5ec93826dc61c19f47c66c0283ee9be980e29ce325a0f4679ef",
@@ -297,7 +297,7 @@ mod tests {
 
     fn hbit_params(
         secret_hash: SecretHash,
-        network: ::bitcoin::Network,
+        network: comit::ledger::Bitcoin,
     ) -> (hbit::SharedParams, bitcoin::SecretKey, bitcoin::SecretKey) {
         let asset = asset::Bitcoin::from_sat(100_000_000);
         let expiry = Timestamp::now().plus(60 * 60);
@@ -356,10 +356,7 @@ mod tests {
             let node_url = blockchain.node_url.clone();
 
             (
-                Arc::new(BitcoindConnector::new(
-                    node_url.clone(),
-                    crate::bitcoin::Network::Regtest,
-                )?),
+                Arc::new(BitcoindConnector::new(node_url.clone())?),
                 node_url,
                 blockchain,
             )
@@ -471,7 +468,7 @@ mod tests {
         let beta_expiry = Timestamp::now().plus(60 * 60);
 
         let (hbit_params, hbit_transient_refund_sk, hbit_transient_redeem_sk) =
-            hbit_params(secret_hash, bitcoin_network);
+            hbit_params(secret_hash, bitcoin_network.into());
 
         let herc20_params = herc20::params(
             secret_hash,

--- a/src/swap/bitcoin.rs
+++ b/src/swap/bitcoin.rs
@@ -22,7 +22,7 @@ impl hbit::ExecuteFund for Wallet {
 
         let txid = self
             .inner
-            .send_to_address(action.to, action.amount.into(), action.network)
+            .send_to_address(action.to, action.amount.into(), action.network.into())
             .await?;
 
         // we send money to a single address, vout is always 0
@@ -102,7 +102,7 @@ impl Wallet {
     ) -> anyhow::Result<bitcoin::Transaction> {
         let _txid = self
             .inner
-            .send_raw_transaction(action.transaction.clone(), action.network)
+            .send_raw_transaction(action.transaction.clone(), action.network.into())
             .await?;
 
         Ok(action.transaction)

--- a/src/swap/comit/hbit.rs
+++ b/src/swap/comit/hbit.rs
@@ -71,8 +71,8 @@ where
 #[cfg(test)]
 mod arbitrary {
     use crate::swap::hbit::{Params, SharedParams};
-    use ::bitcoin::{secp256k1::SecretKey, Network};
-    use comit::{asset, identity};
+    use ::bitcoin::secp256k1::SecretKey;
+    use comit::{asset, identity, ledger};
     use quickcheck::{Arbitrary, Gen};
 
     impl Arbitrary for Params {
@@ -99,11 +99,11 @@ mod arbitrary {
         SecretKey::from_slice(&bytes).unwrap()
     }
 
-    fn bitcoin_network<G: Gen>(g: &mut G) -> Network {
+    fn bitcoin_network<G: Gen>(g: &mut G) -> ledger::Bitcoin {
         match u8::arbitrary(g) % 3 {
-            0 => Network::Bitcoin,
-            1 => Network::Testnet,
-            2 => Network::Regtest,
+            0 => ledger::Bitcoin::Mainnet,
+            1 => ledger::Bitcoin::Testnet,
+            2 => ledger::Bitcoin::Regtest,
             _ => unreachable!(),
         }
     }

--- a/src/swap/db/hbit.rs
+++ b/src/swap/db/hbit.rs
@@ -239,7 +239,7 @@ impl From<Params> for hbit::Params {
 
         hbit::Params {
             shared: hbit::SharedParams {
-                network,
+                network: network.into(),
                 asset: asset.into(),
                 redeem_identity,
                 refund_identity,
@@ -254,7 +254,7 @@ impl From<Params> for hbit::Params {
 impl From<hbit::Params> for Params {
     fn from(params: hbit::Params) -> Self {
         Params {
-            network: params.shared.network,
+            network: params.shared.network.into(),
             asset: params.shared.asset.into(),
             redeem_identity: params.shared.redeem_identity,
             refund_identity: params.shared.refund_identity,


### PR DESCRIPTION
The overall goal of this commit is bring nectar up to date with commit and reduce type duplication. Changed the BtcDaiOrderForm struct to use the price quantity model that was recently adopted by comit-rs. The bitcoin and dai asset types were removed because the btc and eth networks were no longer required. The PRECISION constant was fixed which was causing a 1 decimal place conversion error.